### PR TITLE
ci: update dependabot reviewer and prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,25 +5,25 @@ updates:
     schedule:
       interval: "daily"
     reviewers: 
-      - "MaxJPRey"
+      - "SMoraisAnsys"
     assignees:
       - "pyansys-ci-bot"
     labels:
       - "maintenance"
       - "dependencies"
     commit-message:
-      prefix: "MAINT"
+      prefix: "maint"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
     reviewers: 
-      - "MaxJPRey"
+      - "SMoraisAnsys"
     assignees:
       - "pyansys-ci-bot"
     labels:
       - "maintenance"
       - "dependencies"
     commit-message:
-      prefix: "MAINT"
+      prefix: "maint"


### PR DESCRIPTION
Update dependabot to contact me instead of MaxJPRey and change prefix to "maint" 