### PR TITLE
CI: fix non deterministic test failing

### DIFF
--- a/.github/workflows/legacy_tests.yml
+++ b/.github/workflows/legacy_tests.yml
@@ -36,19 +36,32 @@ jobs:
           python-version: '3.10'
           use-cache: false
 
+      - name: Create Python venv
+        run: |
+          python -m venv .venv
+          .\.venv\Scripts\Activate.ps1
+
       - name: "Update pip"
-        run: python -m pip install -U pip
+        run: |
+          .\.venv\Scripts\Activate.ps1
+          python -m pip install -U pip
 
       - name: "Install Python library"
-        run: python -m pip install .
+        run: |
+          .\.venv\Scripts\Activate.ps1
+          python -m pip install .
 
       - name: "Install test requirements"
-        run: python -m pip install .[tests]
+        run: |
+          .\.venv\Scripts\Activate.ps1
+          python -m pip install .[tests]
 
       - name: "Executing legacy unit tests"
         run: |
-          pytest -m "legacy and unit" -n auto -v
+          .\.venv\Scripts\Activate.ps1
+          pytest -m "legacy and unit" -n auto --dist loadfile -v
 
       - name: "Executing legacy system tests (distributing on multiple CPUs)"
         run: |
-          pytest -m "legacy and system and not no_xdist" -n auto -v
+          .\.venv\Scripts\Activate.ps1
+          pytest -m "legacy and system and not no_xdist" -n auto --dist loadfile -v


### PR DESCRIPTION
Leverage the option --dist loadfile which makes tests grouped by their containing file. That way, we can ensure that a worker does all the tests of a file.

Note: on top of that, the workflow legacy_tests now uses a virtual environment.