### PR TITLE
CI: update pip in build doc workflow

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -1,6 +1,6 @@
 name: Documentation Build
 
-on: [pull_request, workflow_dispatch]
+  on: [pull_request, workflow_dispatch]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -29,15 +29,29 @@ jobs:
         with:
           python-version: 3.8
 
+      - name: Create Python venv
+        run: |
+          python -m venv .venv
+          .\.venv\Scripts\Activate.ps1
+
+      - name: "Update pip"
+        run: |
+          .\.venv\Scripts\Activate.ps1
+          python -m pip install -U pip
+
       - name: Install pyedb with doc dependencies
         run: |
+          .\.venv\Scripts\Activate.ps1
           pip install .[doc]
 
       - name: Verify that pyedb can be imported
-        run: python -c "import pyedb"
+        run: |
+          .\.venv\Scripts\Activate.ps1
+          python -c "import pyedb"
 
       - name: Retrieve pyedb version
         run: |
+          .\.venv\Scripts\Activate.ps1
           echo "Pyedb version: $(python -c "from pyedb import __version__; print(); print(__version__)" | tail -1)"
 
       - name: Install doc build requirements
@@ -48,6 +62,7 @@ jobs:
       # NOTE: we have to add the examples file here since it won't be created as gallery is disabled on linux.
       - name: Documentation Build
         run: |
+          .\.venv\Scripts\Activate.ps1
           make -C doc clean
           mkdir doc/source/examples -p
           echo $'Examples\n========' > doc/source/examples/index.rst
@@ -56,6 +71,7 @@ jobs:
       # Verify that sphinx generates no warnings
       - name: Check for warnings
         run: |
+          .\.venv\Scripts\Activate.ps1
           python doc/print_errors.py
 
       - name: Upload Documentation


### PR DESCRIPTION
Needed to ensure that dependabot updates are possible. Otherwise, the bot may submit version changes that won't be pip installable