### PR TITLE
Fix dev documentation job in CI

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -245,7 +245,7 @@ jobs:
       - name: Upload Documentation
         uses: actions/upload-artifact@v4
         with:
-          name: Documentation
+          name: documentation-html
           path: doc/_build/html
           retention-days: 1
 


### PR DESCRIPTION
When uploading dev-documentation or others, the previous downloaded artifact name didn't fit (`Documentation` != `documentation-html`)