### PR TITLE
Fix nightly run examples

### DIFF
--- a/examples/legacy/pyaedt_integration/13_edb_create_component.py
+++ b/examples/legacy/pyaedt_integration/13_edb_create_component.py
@@ -35,9 +35,19 @@ from pyedb.generic.general_methods import (
     generate_unique_name,
 )
 
+##########################################################
+# Set non-graphical mode
+# ~~~~~~~~~~~~~~~~~~~~~~
+# Set non-graphical mode. The default is ``True``.
+
+non_graphical = True
+
+###############################################################################
+# Launch EDB
+# ~~~~~~~~~~
+# Launch the :class:`pyedb.Edb` class, using EDB 2023 R2.
+
 aedb_path = os.path.join(generate_unique_folder_name(), generate_unique_name("component_example") + ".aedb")
-
-
 edb = pyedb.Edb(edbpath=aedb_path, edbversion="2023.2")
 print("EDB is located at {}".format(aedb_path))
 
@@ -194,5 +204,5 @@ edb.build_simulation_project(sim_setup)
 # ~~~~~~~~~~~~~~~~~~~~~~~~~
 edb.save_edb()
 edb.close_edb()
-h3d = Hfss3dLayout(specified_version="2023.2", projectname=aedb_path, non_graphical=False)
+h3d = Hfss3dLayout(specified_version="2023.2", projectname=aedb_path, non_graphical=non_graphical)
 h3d.release_desktop(False, False)

--- a/examples/legacy/pyaedt_integration/14_edb_create_parametrized_design.py
+++ b/examples/legacy/pyaedt_integration/14_edb_create_parametrized_design.py
@@ -31,6 +31,18 @@ project_path = generate_unique_folder_name()
 target_aedb = download_file("edb/ANSYS-HSD_V1.aedb", destination=project_path)
 print("Project folder will be", target_aedb)
 
+##########################################################
+# Set non-graphical mode
+# ~~~~~~~~~~~~~~~~~~~~~~
+# Set non-graphical mode. The default is ``True``.
+
+non_graphical = True
+
+###############################################################################
+# Launch EDB
+# ~~~~~~~~~~
+# Launch the :class:`pyedb.Edb` class, using EDB 2023 R2.
+
 aedt_version = "2023.2"
 edb = pyedb.Edb(edbpath=target_aedb, edbversion=aedt_version)
 print("EDB is located at {}".format(target_aedb))
@@ -67,5 +79,5 @@ edb.close_edb()
 # Open project in AEDT
 # ~~~~~~~~~~~~~~~~~~~~
 
-hfss = Hfss3dLayout(projectname=target_aedb, specified_version=aedt_version)
+hfss = Hfss3dLayout(projectname=target_aedb, specified_version=aedt_version, non_graphical=non_graphical)
 hfss.release_desktop(False, False)


### PR DESCRIPTION
When including the new pyaedt developments related to EDB, the examples were not update to use non_graphical mode as in previous changes.