### PR TITLE
CI: add retry on legacy tests job

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -101,9 +101,14 @@ jobs:
           pip install --extra-index-url https://wheels.vtk.org ${{ env.VTK_OSMESA }}
 
       - name: "Executing legacy tests"
-        run: |
-          . .venv\Scripts\Activate.ps1
-          pytest -m "legacy" -n auto --dist loadfile -v
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          retry_on: error
+          timeout_minutes: 10
+          command: |
+            . .venv\Scripts\Activate.ps1
+            pytest -m "legacy" -n auto --dist loadfile -v
 
       - name: Upload Coverage Results
         if: always()


### PR DESCRIPTION
For some (legacy) reasons the tests might fail sometimes. However it might not be related with the changes associated to the commit triggering the workflow. This PR adds a retry capability to avoid getting stuck due to legacy non reproducible behavior.