### PR TITLE
Edit to overall index.rst file

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -43,6 +43,8 @@ API to make scripting simpler.
         :link: getting_started/contributing
         :link-type: doc
 
+        Learn how to contribute to the PyEDB codebase or documentation.
+
 .. toctree::
    :hidden:
 


### PR DESCRIPTION
Add description for Contribute card. While ``:link: getting_started/contributing`` seems odd as the ``contributing.rst`` file is in the ``doc/source`` directory, the link appears to work.