### PR TITLE
CI: use pyedb runners and cleancup CI/CD workflow

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -12,7 +12,6 @@ env:
   ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
   PYEDB_USE_DOTNET: '1'
   MAIN_PYTHON_VERSION: '3.10'
-  MAIN_PYTHON_VERSION_WINDOWS_SELFHOSTED: '3.9'
   PACKAGE_NAME: 'pyedb'
   DOCUMENTATION_CNAME: 'edb.docs.pyansys.com'
   VTK_OSMESA: 'vtk-osmesa==9.2.20230527.dev0'
@@ -63,7 +62,7 @@ jobs:
 
   legacy-tests:
     name: Test dotnet
-    runs-on: [ Windows, pyaedt ]
+    runs-on: [ Windows, self-hosted, pyedb ]
     steps:
       - name: "Install Git and clone project"
         uses: actions/checkout@v4
@@ -71,7 +70,7 @@ jobs:
       - name: "Set up Python"
         uses: ansys/actions/_setup-python@v5
         with:
-          python-version: ${{ env.MAIN_PYTHON_VERSION_WINDOWS_SELFHOSTED }}
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
           use-cache: false
 
       - name: Create Python venv
@@ -135,7 +134,7 @@ jobs:
 
   docs-build:
     name: Build documentation
-    runs-on: [ Windows, pyaedt ]
+    runs-on: [ Windows, self-hosted, pyedb ]
     timeout-minutes: 480
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Previous changes to go public included the fact of using pyaedt runners since our runner was not part of ansys.
This should not be the case now.