### PR TITLE
MAINT: Use ansys-edb-core dependency

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: "Set up Python"
-        uses: ansys/actions/_setup-python@v5
+        uses: ansys/actions/_setup-python@v4
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
           use-cache: false
@@ -140,7 +140,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: "Set up Python"
-        uses: ansys/actions/_setup-python@v5
+        uses: ansys/actions/_setup-python@v4
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
           use-cache: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,9 @@ full = [
     "scikit-rf",
     "openpyxl==3.1.2",
 ]
-grpc = ["ansys-edb@git+ssh://git@github.com/ansys/pyedb-core"]
+grpc = [
+    "ansys-edb-core"
+]
 
 [tool.flit.module]
 name = "pyedb"


### PR DESCRIPTION
Publishing to pypi got canceled because we had a dependency to pyedb-core.
This package is now named ansys-edb-core and available on pypi !