### PR TITLE
MAINT: Add python 3 7 compatibility

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         should-release:
           - ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags') }}
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Information Analysis",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "pyedb"
 dynamic = ["version"]
 description = "Higher-Level Pythonic Ansys Electronics Data Base"
 readme = "README.md"
-requires-python = ">=3.8,<4"
+requires-python = ">=3.7,<4"
 license = {file = "LICENSE"}
 authors = [{name = "ANSYS, Inc.", email = "pyansys.core@ansys.com"}]
 maintainers = [{name = "PyEDB developers", email = "simon.vandenbrouck@ansys.com"}]

--- a/src/pyedb/__init__.py
+++ b/src/pyedb/__init__.py
@@ -1,17 +1,52 @@
 # -*- coding: utf-8 -*-
 import os
+import sys
+import warnings
 
 if os.name == "nt":
     os.environ["PYTHONMALLOC"] = "malloc"
 
-pyedb_path = os.path.dirname(__file__)
-
-__version__ = "0.4.dev0"
-
-version = __version__
-
 # By default we use pyedb legacy implementation
 if "PYEDB_USE_DOTNET" not in os.environ:
     os.environ["PYEDB_USE_DOTNET"] = "0"
+
+LATEST_DEPRECATED_PYTHON_VERSION = (3, 7)
+
+
+def deprecation_warning():
+    """Warning message informing users that some Python versions are deprecated in PyEDB."""
+    # Store warnings showwarning
+    existing_showwarning = warnings.showwarning
+
+    # Define and use custom showwarning
+    def custom_show_warning(message, category, filename, lineno, file=None, line=None):
+        """Custom warning used to remove <stdin>:loc: pattern."""
+        print(f"{category.__name__}: {message}")
+
+    warnings.showwarning = custom_show_warning
+
+    current_version = sys.version_info[:2]
+    if current_version <= LATEST_DEPRECATED_PYTHON_VERSION:
+        str_current_version = "{}.{}".format(*sys.version_info[:2])
+        warnings.warn(
+            "Current python version ({}) is deprecated in PyEDB. We encourage you "
+            "to upgrade to the latest version to benefit from the latest features "
+            "and security updates.".format(str_current_version),
+            PendingDeprecationWarning,
+        )
+
+    # Restore warnings showwarning
+    warnings.showwarning = existing_showwarning
+
+
+deprecation_warning()
+
+#
+
+pyedb_path = os.path.dirname(__file__)
+__version__ = "0.4.dev0"
+version = __version__
+
+#
 
 from pyedb.generic.design_types import Edb

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -1,0 +1,23 @@
+import sys
+from unittest.mock import patch
+import warnings
+
+from pyedb import LATEST_DEPRECATED_PYTHON_VERSION
+from pyedb import deprecation_warning
+
+
+@patch.object(warnings, "warn")
+def test_deprecation_warning(mock_warn):
+    deprecation_warning()
+
+    current_version = sys.version_info[:2]
+    if current_version <= LATEST_DEPRECATED_PYTHON_VERSION:
+        str_current_version = "{}.{}".format(*sys.version_info[:2])
+        expected = (
+            "Current python version ({}) is deprecated in PyEDB. We encourage you "
+            "to upgrade to the latest version to benefit from the latest features "
+            "and security updates.".format(str_current_version)
+        )
+        mock_warn.assert_called_once_with(expected, PendingDeprecationWarning)
+    else:
+        mock_warn.assert_not_called()


### PR DESCRIPTION
This PR add python 3.7 as a valid python version for PyEDB. On top of that, the smoke tests have been added to increase the range of python version tested.

Since this python version has been added to allow users to install PyAEDT with version 3.7, a deprecated warning is triggered to notify the users of an incoming deprecation. This deprecated warning is tests.