### PR TITLE
bugfix edb_stats occupying ratio per layer

### DIFF
--- a/src/pyedb/dotnet/edb_core/edb_data/utilities.py
+++ b/src/pyedb/dotnet/edb_core/edb_data/utilities.py
@@ -46,8 +46,8 @@ class EDBStatistics(object):
         self._nb_layer = 0
         self._stackup_thickness = 0.0
         self._nb_vias = 0
-        self._occupying_ratio = 0.0
-        self._occupying_surface = 0.0
+        self._occupying_ratio = {}
+        self._occupying_surface = {}
         self._layout_size = [0.0, 0.0, 0.0, 0.0]
         self._nb_polygons = 0
         self._nb_traces = 0

--- a/src/pyedb/dotnet/edb_core/layout.py
+++ b/src/pyedb/dotnet/edb_core/layout.py
@@ -1256,8 +1256,6 @@ class EdbLayout(object):
         stat_model.stackup_thickness = self._pedb.stackup.get_layout_thickness()
         if evaluate_area:
             outline_surface = stat_model.layout_size[0] * stat_model.layout_size[1]
-            #occupying_surface = {}
-            #accupying_ratio = {}
             if net_list:
                 netlist = list(self._pedb.nets.nets.keys())
                 _poly = self._pedb.get_conformal_polygon_from_netlist(netlist)

--- a/src/pyedb/dotnet/edb_core/layout.py
+++ b/src/pyedb/dotnet/edb_core/layout.py
@@ -1255,12 +1255,21 @@ class EdbLayout(object):
         stat_model.num_vias = len(self._pedb.padstacks.instances)
         stat_model.stackup_thickness = self._pedb.stackup.get_layout_thickness()
         if evaluate_area:
+            outline_surface = stat_model.layout_size[0] * stat_model.layout_size[1]
+            #occupying_surface = {}
+            #accupying_ratio = {}
             if net_list:
                 netlist = list(self._pedb.nets.nets.keys())
                 _poly = self._pedb.get_conformal_polygon_from_netlist(netlist)
             else:
-                _poly = self._pedb.get_conformal_polygon_from_netlist()
-            stat_model.occupying_surface = _poly.Area()
-            outline_surface = stat_model.layout_size[0] * stat_model.layout_size[1]
-            stat_model.occupying_ratio = stat_model.occupying_surface / outline_surface
+                for layer in list(self._pedb.stackup.signal_layers.keys()):
+                    surface = 0.0
+                    primitives = self.primitives_by_layer[layer]
+                    for prim in primitives:
+                        if prim.type == "Path":
+                            surface += prim.length * prim.width
+                        if prim.type == "Polygon":
+                            surface += prim.polygon_data.edb_api.Area()
+                            stat_model.occupying_surface[layer] = surface
+                            stat_model.occupying_ratio[layer] = surface / outline_surface
         return stat_model

--- a/tests/legacy/system/test_edb.py
+++ b/tests/legacy/system/test_edb.py
@@ -599,6 +599,9 @@ class TestClass:
         assert edb_stats.num_inductors
         assert edb_stats.num_capacitors
         assert edb_stats.num_resistors
+        assert edb_stats.occupying_ratio["1_Top"] == 0.3016820127679697
+        assert edb_stats.occupying_ratio["Inner1(GND1)"] == 0.9374673461236078
+        assert edb_stats.occupying_ratio["16_Bottom"] == 0.20492545496020312
         edb.close()
 
     def test_hfss_set_bounding_box_extent(self):


### PR DESCRIPTION
Fixing bug on occupying ratio with edb stats computation:
- implementation more accurate
- surface accounted for path and polygons