### PR TITLE
layer getter has changed and is now returning the Edb object

### DIFF
--- a/src/pyedb/dotnet/edb_core/hfss.py
+++ b/src/pyedb/dotnet/edb_core/hfss.py
@@ -1165,7 +1165,7 @@ class EdbHfss(object):
                                     if not ref_prim:
                                         self._logger.error("Failed to collect valid reference primitives for terminal")
                                 if ref_prim:
-                                    reference_layer = ref_prim[0].layer
+                                    reference_layer = ref_prim[0].layer._edb_layer
                                     if term.SetReferenceLayer(reference_layer):  # pragma no cover
                                         self._logger.info("Port {} created".format(port_name))
             return terminal_info

--- a/tests/legacy/system/test_edb.py
+++ b/tests/legacy/system/test_edb.py
@@ -1732,4 +1732,3 @@ class TestClass:
         assert defined_ports
         assert project_connexions
         edb.close_edb()
-

--- a/tests/legacy/system/test_edb.py
+++ b/tests/legacy/system/test_edb.py
@@ -1718,3 +1718,18 @@ class TestClass:
         assert polygon.move_layer("GND")
         assert len(edbapp.modeler.polygons) == 1
         assert edbapp.modeler.polygons[0].layer_name == "GND"
+
+    def test_multizone(self):
+        edb = Edb(
+            edbpath=os.path.join(local_path, "example_models", "multi_zone_project.aedb"),
+            edbversion=desktop_version,
+        )
+        common_reference_net = "gnd"
+        edb_zones = edb.copy_zones()
+        assert edb_zones
+        defined_ports, project_connexions = edb.cutout_multizone_layout(edb_zones, common_reference_net)
+
+        assert defined_ports
+        assert project_connexions
+        edb.close_edb()
+


### PR DESCRIPTION
this is breaking method create_vertical_circuit_port_on_clipped_traces that is not tested in EDB but in PyAEDT.

Added unit tests