### PR TITLE
CHORE: Fix precommit failure

### DIFF
--- a/src/pyedb/dotnet/edb_core/stackup.py
+++ b/src/pyedb/dotnet/edb_core/stackup.py
@@ -2193,9 +2193,10 @@ class Stackup(object):
         file_path : str
             Path to stackup file.
         rename : bool
-            If rename is ``False`` then layer in layout not found in the stackup file are deleted. Otherwise, if the number of layer
-            in the stackup file equals the number of stackup layer in the layout, layers are renamed according the the
-            file. Note that layer order matters, and has to be writtent from top to bottom layer in the file.
+            If rename is ``False`` then layer in layout not found in the stackup file are deleted.
+            Otherwise, if the number of layer in the stackup file equals the number of stackup layer
+            in the layout, layers are renamed according the the file.
+            Note that layer order matters, and has to be writtent from top to bottom layer in the file.
 
         Returns
         -------


### PR DESCRIPTION
As title says.

Note: previously, pre-commit wasn't blocking PR from being merged which explains why a PR got merged while pre-commit pr was failing. This is no longer possible.