### PR TITLE
DOC: Remove non standard link to image

### DIFF
--- a/doc/source/getting_started/about.rst
+++ b/doc/source/getting_started/about.rst
@@ -34,11 +34,6 @@ translation through simulation results.
 Additionally, you can use PyAEDT to import an AEDB file into AEDT to view a project,
 combine 3D designs, or perform simulation postprocessing. EDB also supports 3D component models.
 
-.. image:: https://images.ansys.com/is/image/ansys/ansys-electronics-technology-collage?wid=941&op_usm=0.9,1.0,20,0&fit=constrain,0
-  :width: 800
-  :alt: AEDT Applications
-  :target: https://www.ansys.com/products/electronics
-
 Why use PyEDB?
 --------------
 PyEDB interacts with the `PyEDB-Core <https://github.com/ansys/pyedb-core>`_ API to make scripting simpler.


### PR DESCRIPTION
When trying to use the following documentation directive, we end up with an error when building the PDF file.

```
.. image:: https://images.ansys.com/is/image/ansys/ansys-electronics-technology-collage?wid=941&op_usm=0.9,1.0,20,0&fit=constrain,0
  :width: 800
  :alt: AEDT Applications
  :target: https://www.ansys.com/products/electronics
```

It seems that the image URL is not standard (doesn't ends on png or other format file) which leads to an error.
Since it was just a reference to pyaedt, I propose to remove it for the moment.

**Note**: Another solution would be to save the file inside the repo and leverage this image later on. However, it will make the repo "heavier".

Closes #334 