### PR TITLE
FIX: Ansys version bug fix with mesh via plating

### DIFF
--- a/src/pyedb/dotnet/edb_core/edb_data/hfss_simulation_setup_data.py
+++ b/src/pyedb/dotnet/edb_core/edb_data/hfss_simulation_setup_data.py
@@ -981,7 +981,7 @@ class ViaSettings(object):
 
     @via_mesh_plating.setter
     def via_mesh_plating(self, value):
-        if self._parent._pedb.version[0] >= 10:
+        if int(self._parent._pedb.edbversion.split(".")[0]) >= 2024:
             self._via_settings.ViaMeshPlating = value
             self._parent._update_setup()
         else:


### PR DESCRIPTION
Ansys version check was not working properly. Since the via mesh plating is available only for Ansys release 2024 or higher this issue had to be fixed.