### PR TITLE
TEST: Materials load_material method

### DIFF
--- a/src/pyedb/dotnet/edb_core/materials.py
+++ b/src/pyedb/dotnet/edb_core/materials.py
@@ -413,7 +413,7 @@ class Material(object):
             for attribute in ATTRIBUTES:
                 if attribute in input_dict:
                     setattr(self, attribute, input_dict[attribute])
-            if "loss_tangent" in input_dict: # pragma: no cover
+            if "loss_tangent" in input_dict:  # pragma: no cover
                 setattr(self, "loss_tangent", input_dict["loss_tangent"])
 
             # Update DS model
@@ -534,7 +534,7 @@ class Materials(object):
         material_def = self.__edb_definition.MaterialDef.Create(self.__edb.active_db, name)
         material = Material(self.__edb, material_def)
         attributes_input_dict = {key: val for (key, val) in kwargs.items() if key in ATTRIBUTES + DC_ATTRIBUTES}
-        if "loss_tangent" in kwargs: # pragma: no cover
+        if "loss_tangent" in kwargs:  # pragma: no cover
             warnings.warn(
                 "This key is deprecated in versions >0.7.0 and will soon be removed. "
                 "Use key dielectric_loss_tangent instead.",
@@ -637,7 +637,7 @@ class Materials(object):
             material = self.__add_dielectric_material_model(name, material_model)
             for key, value in kwargs.items():
                 setattr(material, key, value)
-            if "loss_tangent" in kwargs: # pragma: no cover
+            if "loss_tangent" in kwargs:  # pragma: no cover
                 warnings.warn(
                     "This key is deprecated in versions >0.7.0 and will soon be removed. "
                     "Use key dielectric_loss_tangent instead.",
@@ -703,7 +703,7 @@ class Materials(object):
             material = self.__add_dielectric_material_model(name, material_model)
             for key, value in kwargs.items():
                 setattr(material, key, value)
-            if "loss_tangent" in kwargs: # pragma: no cover
+            if "loss_tangent" in kwargs:  # pragma: no cover
                 warnings.warn(
                     "This key is deprecated in versions >0.7.0 and will soon be removed. "
                     "Use key dielectric_loss_tangent instead.",
@@ -766,7 +766,7 @@ class Materials(object):
             material = self.__add_dielectric_material_model(name, material_model)
             for key, value in kwargs.items():
                 setattr(material, key, value)
-            if "loss_tangent" in kwargs: # pragma: no cover
+            if "loss_tangent" in kwargs:  # pragma: no cover
                 warnings.warn(
                     "This key is deprecated in versions >0.7.0 and will soon be removed. "
                     "Use key dielectric_loss_tangent instead.",
@@ -842,7 +842,7 @@ class Materials(object):
 
         material = self[material_name]
         attributes_input_dict = {key: val for (key, val) in input_dict.items() if key in ATTRIBUTES + DC_ATTRIBUTES}
-        if "loss_tangent" in input_dict: # pragma: no cover
+        if "loss_tangent" in input_dict:  # pragma: no cover
             warnings.warn(
                 "This key is deprecated in versions >0.7.0 and will soon be removed. "
                 "Use key dielectric_loss_tangent instead.",
@@ -864,7 +864,7 @@ class Materials(object):
                 self.add_conductor_material(material_name, material_conductivity)
             else:
                 material_permittivity = material["permittivity"]
-                if "loss_tangent" in material: # pragma: no cover
+                if "loss_tangent" in material:  # pragma: no cover
                     warnings.warn(
                         "This key is deprecated in versions >0.7.0 and will soon be removed. "
                         "Use key dielectric_loss_tangent instead.",
@@ -938,7 +938,7 @@ class Materials(object):
                 if "tangent_delta" in material_properties:
                     material_properties["dielectric_loss_tangent"] = material_properties["tangent_delta"]
                     del material_properties["tangent_delta"]
-                elif "loss_tangent" in material_properties: # pragma: no cover
+                elif "loss_tangent" in material_properties:  # pragma: no cover
                     warnings.warn(
                         "This key is deprecated in versions >0.7.0 and will soon be removed. "
                         "Use key dielectric_loss_tangent instead.",

--- a/src/pyedb/dotnet/edb_core/materials.py
+++ b/src/pyedb/dotnet/edb_core/materials.py
@@ -413,7 +413,7 @@ class Material(object):
             for attribute in ATTRIBUTES:
                 if attribute in input_dict:
                     setattr(self, attribute, input_dict[attribute])
-            if "loss_tangent" in input_dict:
+            if "loss_tangent" in input_dict: # pragma: no cover
                 setattr(self, "loss_tangent", input_dict["loss_tangent"])
 
             # Update DS model
@@ -534,7 +534,7 @@ class Materials(object):
         material_def = self.__edb_definition.MaterialDef.Create(self.__edb.active_db, name)
         material = Material(self.__edb, material_def)
         attributes_input_dict = {key: val for (key, val) in kwargs.items() if key in ATTRIBUTES + DC_ATTRIBUTES}
-        if "loss_tangent" in kwargs:
+        if "loss_tangent" in kwargs: # pragma: no cover
             warnings.warn(
                 "This key is deprecated in versions >0.7.0 and will soon be removed. "
                 "Use key dielectric_loss_tangent instead.",
@@ -637,7 +637,7 @@ class Materials(object):
             material = self.__add_dielectric_material_model(name, material_model)
             for key, value in kwargs.items():
                 setattr(material, key, value)
-            if "loss_tangent" in kwargs:
+            if "loss_tangent" in kwargs: # pragma: no cover
                 warnings.warn(
                     "This key is deprecated in versions >0.7.0 and will soon be removed. "
                     "Use key dielectric_loss_tangent instead.",
@@ -703,7 +703,7 @@ class Materials(object):
             material = self.__add_dielectric_material_model(name, material_model)
             for key, value in kwargs.items():
                 setattr(material, key, value)
-            if "loss_tangent" in kwargs:
+            if "loss_tangent" in kwargs: # pragma: no cover
                 warnings.warn(
                     "This key is deprecated in versions >0.7.0 and will soon be removed. "
                     "Use key dielectric_loss_tangent instead.",
@@ -766,7 +766,7 @@ class Materials(object):
             material = self.__add_dielectric_material_model(name, material_model)
             for key, value in kwargs.items():
                 setattr(material, key, value)
-            if "loss_tangent" in kwargs:
+            if "loss_tangent" in kwargs: # pragma: no cover
                 warnings.warn(
                     "This key is deprecated in versions >0.7.0 and will soon be removed. "
                     "Use key dielectric_loss_tangent instead.",
@@ -842,7 +842,7 @@ class Materials(object):
 
         material = self[material_name]
         attributes_input_dict = {key: val for (key, val) in input_dict.items() if key in ATTRIBUTES + DC_ATTRIBUTES}
-        if "loss_tangent" in input_dict:
+        if "loss_tangent" in input_dict: # pragma: no cover
             warnings.warn(
                 "This key is deprecated in versions >0.7.0 and will soon be removed. "
                 "Use key dielectric_loss_tangent instead.",
@@ -864,7 +864,7 @@ class Materials(object):
                 self.add_conductor_material(material_name, material_conductivity)
             else:
                 material_permittivity = material["permittivity"]
-                if "loss_tangent" in material:
+                if "loss_tangent" in material: # pragma: no cover
                     warnings.warn(
                         "This key is deprecated in versions >0.7.0 and will soon be removed. "
                         "Use key dielectric_loss_tangent instead.",
@@ -938,7 +938,7 @@ class Materials(object):
                 if "tangent_delta" in material_properties:
                     material_properties["dielectric_loss_tangent"] = material_properties["tangent_delta"]
                     del material_properties["tangent_delta"]
-                elif "loss_tangent" in material_properties:
+                elif "loss_tangent" in material_properties: # pragma: no cover
                     warnings.warn(
                         "This key is deprecated in versions >0.7.0 and will soon be removed. "
                         "Use key dielectric_loss_tangent instead.",

--- a/tests/legacy/system/test_edb_materials.py
+++ b/tests/legacy/system/test_edb_materials.py
@@ -299,7 +299,7 @@ class TestClass:
         assert MATERIAL_NAME not in materials
         materials.load_material(conductor_material_properties)
         material = materials[MATERIAL_NAME]
-        assert 12 == material.conductivity
+        assert 2e4 == material.conductivity
 
     def test_materials_load_dielectric_material(self):
         """Load dielectric material."""

--- a/tests/legacy/system/test_edb_materials.py
+++ b/tests/legacy/system/test_edb_materials.py
@@ -86,6 +86,7 @@ class TestClass:
             for value in VALUES:
                 setattr(material, property, value)
                 assert float(value) == getattr(material, property)
+        assert 12 == material.loss_tangent
 
     def test_material_dc_properties(self):
         """Evaluate material DC properties."""
@@ -289,3 +290,21 @@ class TestClass:
         assert name_to_material[key]["mass_density"] == 8055
         assert name_to_material[key]["specific_heat"] == 480
         assert name_to_material[key]["thermal_expansion_coefficient"] == 1.08e-005
+
+    def test_materials_load_material(self):
+        """Evaluate load material."""
+        materials = Materials(self.edbapp)
+        material_properties = {
+            "name": MATERIAL_NAME,
+            "conductivity": 12,
+            "permittivity": 12,
+            "loss_tangent": 0.00045
+        }
+
+        assert MATERIAL_NAME not in materials
+        materials.load_material(material_properties)
+        material = materials[MATERIAL_NAME]
+        assert 0.00045 == material.loss_tangent
+        assert 0.00045 == material.dielectric_loss_tangent
+        assert 12 == material.conductivity
+        assert 12 == material.permittivity

--- a/tests/legacy/system/test_edb_materials.py
+++ b/tests/legacy/system/test_edb_materials.py
@@ -294,12 +294,7 @@ class TestClass:
     def test_materials_load_material(self):
         """Evaluate load material."""
         materials = Materials(self.edbapp)
-        material_properties = {
-            "name": MATERIAL_NAME,
-            "conductivity": 12,
-            "permittivity": 12,
-            "loss_tangent": 0.00045
-        }
+        material_properties = {"name": MATERIAL_NAME, "conductivity": 12, "permittivity": 12, "loss_tangent": 0.00045}
 
         assert MATERIAL_NAME not in materials
         materials.load_material(material_properties)

--- a/tests/legacy/system/test_edb_materials.py
+++ b/tests/legacy/system/test_edb_materials.py
@@ -295,7 +295,7 @@ class TestClass:
         """Load conductor material."""
         materials = Materials(self.edbapp)
         conductor_material_properties = {"name": MATERIAL_NAME, "conductivity": 2e4}
-        
+
         assert MATERIAL_NAME not in materials
         materials.load_material(conductor_material_properties)
         material = materials[MATERIAL_NAME]

--- a/tests/legacy/system/test_edb_materials.py
+++ b/tests/legacy/system/test_edb_materials.py
@@ -291,15 +291,24 @@ class TestClass:
         assert name_to_material[key]["specific_heat"] == 480
         assert name_to_material[key]["thermal_expansion_coefficient"] == 1.08e-005
 
-    def test_materials_load_material(self):
-        """Evaluate load material."""
+    def test_materials_load_conductor_material(self):
+        """Load conductor material."""
         materials = Materials(self.edbapp)
-        material_properties = {"name": MATERIAL_NAME, "conductivity": 12, "permittivity": 12, "loss_tangent": 0.00045}
+        conductor_material_properties = {"name": MATERIAL_NAME, "conductivity": 2e4}
+        
+        assert MATERIAL_NAME not in materials
+        materials.load_material(conductor_material_properties)
+        material = materials[MATERIAL_NAME]
+        assert 12 == material.conductivity
+
+    def test_materials_load_dielectric_material(self):
+        """Load dielectric material."""
+        materials = Materials(self.edbapp)
+        dielectric_material_properties = {"name": MATERIAL_NAME, "permittivity": 12, "loss_tangent": 0.00045}
 
         assert MATERIAL_NAME not in materials
-        materials.load_material(material_properties)
+        materials.load_material(dielectric_material_properties)
         material = materials[MATERIAL_NAME]
         assert 0.00045 == material.loss_tangent
         assert 0.00045 == material.dielectric_loss_tangent
-        assert 12 == material.conductivity
         assert 12 == material.permittivity


### PR DESCRIPTION
Extend tests with `test_materials_load_material`.
On top of that, we avoid covering lines of code related to the use of the deprecated `loss_tangent`.

Closes #368 