### PR TITLE
FIX: Stackup export to JSON file

### DIFF
--- a/src/pyedb/dotnet/edb_core/stackup.py
+++ b/src/pyedb/dotnet/edb_core/stackup.py
@@ -1042,8 +1042,8 @@ class Stackup(LayerCollection):
     def _export_layer_stackup_to_json(self, output_file=None, include_material_with_layer=False):
         if not include_material_with_layer:
             material_out = {}
-            for k, v in self._pedb.materials.materials.items():
-                material_out[k] = v._json_format()
+            for material_name, material in self._pedb.materials.materials.items():
+                material_out[material_name] = material.to_dict()
         layers_out = {}
         for k, v in self.stackup_layers.items():
             layers_out[k] = v._json_format()
@@ -1054,9 +1054,9 @@ class Stackup(LayerCollection):
                 else:
                     dielectric_fill = self._pedb.materials.materials[v.dielectric_fill]
                 if include_material_with_layer:
-                    layers_out[k]["material"] = layer_material._json_format()
+                    layers_out[k]["material"] = layer_material.to_dict()
                     if dielectric_fill:
-                        layers_out[k]["dielectric_fill"] = dielectric_fill._json_format()
+                        layers_out[k]["dielectric_fill"] = dielectric_fill.to_dict()
         if not include_material_with_layer:
             stackup_out = {"materials": material_out, "layers": layers_out}
         else:

--- a/src/pyedb/dotnet/edb_core/stackup.py
+++ b/src/pyedb/dotnet/edb_core/stackup.py
@@ -1046,7 +1046,11 @@ class Stackup(LayerCollection):
                 material_out[material_name] = material.to_dict()
         layers_out = {}
         for k, v in self.stackup_layers.items():
-            layers_out[k] = v._json_format()
+            data = v._json_format()
+            # FIXME: Update the API to avoid providing following information to our users
+            del data["pedb"]
+            del data["edb_object"]
+            layers_out[k] = data
             if v.material in self._pedb.materials.materials:
                 layer_material = self._pedb.materials.materials[v.material]
                 if not v.dielectric_fill:

--- a/tests/legacy/system/test_edb_stackup.py
+++ b/tests/legacy/system/test_edb_stackup.py
@@ -374,6 +374,7 @@ class TestClass:
             assert MATERIAL_MEGTRON_4 == data["materials"]["Megtron4"]
             # Check layer
             assert LAYER_DE_2 == data["layers"]["DE2"]
+        edbapp.close()
 
     def test_stackup_load_xml(self, edb_examples):
         edbapp = edb_examples.get_si_verse()

--- a/tests/legacy/system/test_edb_stackup.py
+++ b/tests/legacy/system/test_edb_stackup.py
@@ -322,6 +322,44 @@ class TestClass:
         edbapp.stackup.load(fpath)
         edbapp.close()
 
+    def test_stackup_export_json(self):
+        """Export stackup into a JSON file."""
+        import json
+        MATERIAL_MEGTRON_4 = {
+            'name': 'Megtron4',
+            'conductivity': 0.0,
+            'dielectric_loss_tangent': 0.005,
+            'magnetic_loss_tangent': 0.0,
+            'mass_density': 0.0,
+            'permittivity': 3.77,
+            'permeability': 0.0,
+            'poisson_ratio': 0.0,
+            'specific_heat': 0.0,
+            'thermal_conductivity': 0.0,
+            'youngs_modulus': 0.0,
+            'thermal_expansion_coefficient': 0.0,
+            'dc_conductivity': None,
+            'dc_permittivity': None,
+            'dielectric_model_frequency': None,
+            'loss_tangent_at_frequency': None,
+            'permittivity_at_frequency': None
+        }
+        LAYER_DE_2 = {
+            'name': 'DE2', 'color': (128, 128, 128), 'type': 'dielectric', 'material': 'Megtron4_2', 'dielectric_fill': None, 'thickness': 8.8e-05, 'etch_factor': 0.0, 
+            'roughness_enabled': False, 'top_hallhuray_nodule_radius': 0.0, 'top_hallhuray_surface_ratio': 0.0, 'bottom_hallhuray_nodule_radius': 0.0, 'bottom_hallhuray_surface_ratio': 0.0, 'side_hallhuray_nodule_radius': 0.0, 'side_hallhuray_surface_ratio': 0.0, 'upper_elevation': 0.0, 'lower_elevation': 0.0
+        }
+        source_path = os.path.join(local_path, "example_models", test_subfolder, "ANSYS-HSD_V1.aedb")
+        edbapp = Edb(source_path, edbversion="2023.2")
+        json_path = os.path.join(self.local_scratch.path, "stackup.json")
+
+        assert edbapp.stackup.export(json_path)
+        with open(json_path, 'r') as json_file:
+            data = json.load(json_file)
+            # Check material
+            assert MATERIAL_MEGTRON_4 == data["materials"]["Megtron4"]
+            # Check layer
+            assert LAYER_DE_2 == data["layers"]["DE2"]
+
     def test_stackup_load_xml(self, edb_examples):
         edbapp = edb_examples.get_si_verse()
         assert edbapp.stackup.load(os.path.join(local_path, "example_models", test_subfolder, "ansys_pcb_stackup.xml"))

--- a/tests/legacy/system/test_edb_stackup.py
+++ b/tests/legacy/system/test_edb_stackup.py
@@ -325,35 +325,50 @@ class TestClass:
     def test_stackup_export_json(self):
         """Export stackup into a JSON file."""
         import json
+
         MATERIAL_MEGTRON_4 = {
-            'name': 'Megtron4',
-            'conductivity': 0.0,
-            'dielectric_loss_tangent': 0.005,
-            'magnetic_loss_tangent': 0.0,
-            'mass_density': 0.0,
-            'permittivity': 3.77,
-            'permeability': 0.0,
-            'poisson_ratio': 0.0,
-            'specific_heat': 0.0,
-            'thermal_conductivity': 0.0,
-            'youngs_modulus': 0.0,
-            'thermal_expansion_coefficient': 0.0,
-            'dc_conductivity': None,
-            'dc_permittivity': None,
-            'dielectric_model_frequency': None,
-            'loss_tangent_at_frequency': None,
-            'permittivity_at_frequency': None
+            "name": "Megtron4",
+            "conductivity": 0.0,
+            "dielectric_loss_tangent": 0.005,
+            "magnetic_loss_tangent": 0.0,
+            "mass_density": 0.0,
+            "permittivity": 3.77,
+            "permeability": 0.0,
+            "poisson_ratio": 0.0,
+            "specific_heat": 0.0,
+            "thermal_conductivity": 0.0,
+            "youngs_modulus": 0.0,
+            "thermal_expansion_coefficient": 0.0,
+            "dc_conductivity": None,
+            "dc_permittivity": None,
+            "dielectric_model_frequency": None,
+            "loss_tangent_at_frequency": None,
+            "permittivity_at_frequency": None,
         }
         LAYER_DE_2 = {
-            'name': 'DE2', 'color': (128, 128, 128), 'type': 'dielectric', 'material': 'Megtron4_2', 'dielectric_fill': None, 'thickness': 8.8e-05, 'etch_factor': 0.0, 
-            'roughness_enabled': False, 'top_hallhuray_nodule_radius': 0.0, 'top_hallhuray_surface_ratio': 0.0, 'bottom_hallhuray_nodule_radius': 0.0, 'bottom_hallhuray_surface_ratio': 0.0, 'side_hallhuray_nodule_radius': 0.0, 'side_hallhuray_surface_ratio': 0.0, 'upper_elevation': 0.0, 'lower_elevation': 0.0
+            "name": "DE2",
+            "color": (128, 128, 128),
+            "type": "dielectric",
+            "material": "Megtron4_2",
+            "dielectric_fill": None,
+            "thickness": 8.8e-05,
+            "etch_factor": 0.0,
+            "roughness_enabled": False,
+            "top_hallhuray_nodule_radius": 0.0,
+            "top_hallhuray_surface_ratio": 0.0,
+            "bottom_hallhuray_nodule_radius": 0.0,
+            "bottom_hallhuray_surface_ratio": 0.0,
+            "side_hallhuray_nodule_radius": 0.0,
+            "side_hallhuray_surface_ratio": 0.0,
+            "upper_elevation": 0.0,
+            "lower_elevation": 0.0,
         }
         source_path = os.path.join(local_path, "example_models", test_subfolder, "ANSYS-HSD_V1.aedb")
         edbapp = Edb(source_path, edbversion="2023.2")
         json_path = os.path.join(self.local_scratch.path, "stackup.json")
 
         assert edbapp.stackup.export(json_path)
-        with open(json_path, 'r') as json_file:
+        with open(json_path, "r") as json_file:
             data = json.load(json_file)
             # Check material
             assert MATERIAL_MEGTRON_4 == data["materials"]["Megtron4"]

--- a/tests/legacy/system/test_edb_stackup.py
+++ b/tests/legacy/system/test_edb_stackup.py
@@ -365,7 +365,7 @@ class TestClass:
         }
         source_path = os.path.join(local_path, "example_models", test_subfolder, "ANSYS-HSD_V1.aedb")
         edbapp = Edb(source_path, edbversion=desktop_version)
-        json_path = os.path.join(self.local_scratch.path, "stackup.json")
+        json_path = os.path.join(self.local_scratch.path, "exported_stackup.json")
 
         assert edbapp.stackup.export(json_path)
         with open(json_path, "r") as json_file:

--- a/tests/legacy/system/test_edb_stackup.py
+++ b/tests/legacy/system/test_edb_stackup.py
@@ -347,7 +347,7 @@ class TestClass:
         }
         LAYER_DE_2 = {
             "name": "DE2",
-            "color": (128, 128, 128),
+            "color": [128, 128, 128],
             "type": "dielectric",
             "material": "Megtron4_2",
             "dielectric_fill": None,
@@ -364,7 +364,7 @@ class TestClass:
             "lower_elevation": 0.0,
         }
         source_path = os.path.join(local_path, "example_models", test_subfolder, "ANSYS-HSD_V1.aedb")
-        edbapp = Edb(source_path, edbversion="2023.2")
+        edbapp = Edb(source_path, edbversion=desktop_version)
         json_path = os.path.join(self.local_scratch.path, "stackup.json")
 
         assert edbapp.stackup.export(json_path)


### PR DESCRIPTION
There were two bugs that prevented to export a stackup into a JSON file:
- we were still using `_json_format` call which was removed when refactoring the materials;
- we were trying to serialize data that isn't, aka the "pedb" and edb object associated to each layer.

Closes #468

Note: depending on the use of `_json_format` used in the `stackup_layers` we might also want to rework (and/or rename) that method to avoid passing information that should be passed to our users.