### PR TITLE
REFACTOR: Make plot consistent wrt show

### DIFF
--- a/src/pyedb/dotnet/edb_core/edb_data/nets_data.py
+++ b/src/pyedb/dotnet/edb_core/edb_data/nets_data.py
@@ -123,6 +123,7 @@ class EDBNetsData(NetDotNet):
         save_plot=None,
         outline=None,
         size=(2000, 1000),
+        show=True,
     ):
         """Plot a net to Matplotlib 2D chart.
 
@@ -134,12 +135,14 @@ class EDBNetsData(NetDotNet):
             If `True` the legend is shown in the plot. (default)
             If `False` the legend is not shown.
         save_plot : str, optional
-            If `None` the plot will be shown.
-            If a file path is specified the plot will be saved to such file.
+            If a path is specified the plot will be saved in this location.
+            If ``save_plot`` is provided, the ``show`` parameter is ignored.
         outline : list, optional
             List of points of the outline to plot.
         size : tuple, optional
             Image size in pixel (width, height).
+        show : bool, optional
+            Whether to show the plot or not. Default is `True`.
         """
 
         self._app.nets.plot(
@@ -149,6 +152,7 @@ class EDBNetsData(NetDotNet):
             save_plot=save_plot,
             outline=outline,
             size=size,
+            show=show,
         )
 
     @pyedb_function_handler()

--- a/src/pyedb/dotnet/edb_core/nets.py
+++ b/src/pyedb/dotnet/edb_core/nets.py
@@ -822,6 +822,7 @@ class EdbNets(object):
         size=(2000, 1000),
         plot_components_on_top=False,
         plot_components_on_bottom=False,
+        show=True,
     ):
         """Plot a Net to Matplotlib 2D Chart.
 
@@ -838,8 +839,8 @@ class EdbNets(object):
             If ``True`` the legend is shown in the plot. (default)
             If ``False`` the legend is not shown.
         save_plot : str, optional
-            If ``None`` the plot will be shown.
-            If a file path is specified the plot will be saved to such file.
+            If a path is specified the plot will be saved in this location.
+            If ``save_plot`` is provided, the ``show`` parameter is ignored.
         outline : list, optional
             List of points of the outline to plot.
         size : tuple, int, optional
@@ -852,6 +853,8 @@ class EdbNets(object):
             If ``True``  the components placed on bottom layer are plotted.
             If ``False`` the components are not plotted. (default)
             If nets and/or layers is specified, only the components belonging to the specified nets/layers are plotted.
+        show : bool, optional
+            Whether to show the plot or not. Default is `True`.
         """
         if is_ironpython:
             self._logger.warning("Plot functionalities are enabled only in CPython.")
@@ -880,8 +883,9 @@ class EdbNets(object):
             xlabel="X (m)",
             ylabel="Y (m)",
             title=self._pedb.active_cell.GetName(),
-            snapshot_path=save_plot,
+            save_plot=save_plot,
             axis_equal=True,
+            show=show,
         )
 
     @pyedb_function_handler()

--- a/src/pyedb/dotnet/edb_core/stackup.py
+++ b/src/pyedb/dotnet/edb_core/stackup.py
@@ -2490,6 +2490,7 @@ class Stackup(LayerCollection):
         first_layer=None,
         last_layer=None,
         scale_elevation=True,
+        show=True,
     ):
         """Plot current stackup and, optionally, overlap padstack definitions.
         Plot supports only 'Laminate' and 'Overlapping' stackup types.
@@ -2497,8 +2498,8 @@ class Stackup(LayerCollection):
         Parameters
         ----------
         save_plot : str, optional
-            If ``None`` the plot will be shown.
-            If a file path is specified the plot will be saved to such file.
+            If a path is specified the plot will be saved in this location.
+            If ``save_plot`` is provided, the ``show`` parameter is ignored.
         size : tuple, optional
             Image size in pixel (width, height). Default value is ``(2000, 1500)``
         plot_definitions : str, list, optional
@@ -2511,6 +2512,8 @@ class Stackup(LayerCollection):
         scale_elevation : bool, optional
             The real layer thickness is scaled so that max_thickness = 3 * min_thickness.
             Default is `True`.
+        show : bool, optional
+            Whether to show the plot or not. Default is `True`.
 
         Returns
         -------
@@ -2925,7 +2928,7 @@ class Stackup(LayerCollection):
             xlabel="",
             ylabel="",
             title="",
-            snapshot_path=None,
+            save_plot=None,
             x_limits=[x_min, x_max],
             y_limits=[y_min, y_max],
             axis_equal=False,
@@ -2950,6 +2953,6 @@ class Stackup(LayerCollection):
         plt.tight_layout()
         if save_plot:
             plt.savefig(save_plot)
-        else:
+        elif show:
             plt.show()
         return plt

--- a/src/pyedb/generic/plot.py
+++ b/src/pyedb/generic/plot.py
@@ -41,7 +41,7 @@ def plot_matplotlib(
     xlabel="",
     ylabel="",
     title="",
-    snapshot_path=None,
+    save_plot=None,
     x_limits=None,
     y_limits=None,
     axis_equal=False,
@@ -67,8 +67,9 @@ def plot_matplotlib(
         Plot Y label. Default is `""`.
     title : str, optional
         Plot Title label. Default is `""`.
-    snapshot_path : str, optional
-        Full path to image file if a snapshot is needed. Default is `None`.
+    save_plot : str, optional
+        If a path is specified the plot will be saved in this location.
+        If ``save_plot`` is provided, the ``show`` parameter is ignored.
     x_limits : list, optional
         List of x limits (left and right). Default is `None`.
     y_limits : list, optional
@@ -141,8 +142,8 @@ def plot_matplotlib(
         for annotation in annotations:
             plt.text(annotation[0], annotation[1], annotation[2], **annotation[3])
 
-    if snapshot_path:
-        plt.savefig(snapshot_path)
+    if save_plot:
+        plt.savefig(save_plot)
     elif show:
         plt.show()
     return plt


### PR DESCRIPTION
Some plot related methods were using a `show` argument and this information was not propagated consistently on the other methods. Changes make it so. Also, the parameter of `plot_matplotlib` associated to the saving of the figure has been updated to be consistent with other plot methods, i.e. from argument `snapshot_path` to `save_plot`.

Note: to make things consistent with previous development, if one provides a path to save the figure. The figure won't be shown, even if argument show is set to True.