### PR TITLE
CI: Temporary assign runner to jobs

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -76,7 +76,7 @@ jobs:
 
   legacy-tests:
     name: Test dotnet
-    runs-on: [ Windows, self-hosted, pyedb ]
+    runs-on: [ Windows, self-hosted, pyedb, pyedb-ci-0 ]
     steps:
       - name: "Install Git and clone project"
         uses: actions/checkout@v4
@@ -141,7 +141,7 @@ jobs:
     name: Testing PyAEDT main branch
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     needs: [smoke-tests]
-    runs-on: [ self-hosted, Windows, pyaedt ]
+    runs-on: [ self-hosted, Windows, pyaedt, pyedb-ci-0 ]
     steps:
       - name: Install Git and checkout project
         uses: actions/checkout@v4
@@ -216,7 +216,7 @@ jobs:
 
   docs-build:
     name: Build documentation
-    runs-on: [ Windows, self-hosted, pyedb ]
+    runs-on: [ Windows, self-hosted, pyedb, pyedb-ci-1 ]
     timeout-minutes: 480
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Until we find a solution for the recurrent error with `matplotlib` happening when we run the tests on runner `pyedb-ci-1`, I propose we assign:
- documentation to `pyedb-ci-1`
- legacy tests to `pyedb-ci-0`

For this purpose I extended the labels associated to the runners, we might get rid of that later on. 

Partially address #516 