### PR TITLE
DOCS: Fix path to resoures figures

### DIFF
--- a/doc/source/getting_started/about.rst
+++ b/doc/source/getting_started/about.rst
@@ -49,7 +49,7 @@ and edit projects, run simulations, or perform postprocessing. AEDB files are pr
 meaning that ready-to-solve projects can be written with PyEDB. Therefore Ansys solvers can directly
 load AEDB files graphically or in batch non-graphically to support submission for job scheduling on a cluster.
 
-.. image:: ../Resources/aedt_3.png
+.. image:: ../resources/aedt_3.png
   :width: 800
   :alt: AEDT Applications
   :target: https://www.ansys.com/products/electronics

--- a/doc/source/user_guide/edb_information_queries/get_layout_bounding_box.rst
+++ b/doc/source/user_guide/edb_information_queries/get_layout_bounding_box.rst
@@ -20,6 +20,6 @@ This tutorial shows how to retrieve the layout size by getting the bounding box.
 
     edbapp.get_bounding_box()
 
-.. .. image:: ../../Resources/layout_bbox.png
-..     :width: 800
-..     :alt: Layout bounding box
+.. image:: ../../resources/layout_bbox.png
+    :width: 800
+    :alt: Layout bounding box

--- a/doc/source/user_guide/excitations/create_circuit_ports_on_component.rst
+++ b/doc/source/user_guide/excitations/create_circuit_ports_on_component.rst
@@ -37,6 +37,6 @@ This page shows how to retrieve pins and create a circuit port on a component.
     edbapp.close_edb()
 
 
-.. image:: ../../Resources/create_circuit_ports_on_component.png
-..     :width: 800
-..     :alt: Circuit port created on a component
+.. image:: ../../resources/create_circuit_ports_on_component.png
+    :width: 800
+    :alt: Circuit port created on a component

--- a/doc/source/user_guide/excitations/create_coax_port_on_component.rst
+++ b/doc/source/user_guide/excitations/create_coax_port_on_component.rst
@@ -31,6 +31,6 @@ This page shows how to create an HFSS coaxial port on a component.
 
 The preceding code creates a coaxial port on nets ``DDR4_DSQ0_P`` and ``DDR4_DSQ0_N`` from component ``U1``:
 
-.. image:: ../../Resources/create_port_on_component_simple.png
-..   :width: 800
-..   :alt: HFSS coaxial port created on a component
+.. image:: ../../resources/create_port_on_component_simple.png
+    :width: 800
+    :alt: HFSS coaxial port created on a component

--- a/doc/source/user_guide/excitations/create_current_source.rst
+++ b/doc/source/user_guide/excitations/create_current_source.rst
@@ -64,6 +64,6 @@ This page shows how to create current and voltage sources on a component.
     edbapp.close_edb()
 
 
-.. image:: ../../Resources/create_sources_and_probes.png
-..   :width: 800
-..   :alt: Current and voltage sources created on a component
+.. image:: ../../resources/create_sources_and_probes.png
+    :width: 800
+    :alt: Current and voltage sources created on a component

--- a/doc/source/user_guide/excitations/create_edge_port_on_polygon.rst
+++ b/doc/source/user_guide/excitations/create_edge_port_on_polygon.rst
@@ -96,6 +96,6 @@ This page shows how to create an edge port on a polygon and trace.
     edbapp.save_edb()
     edbapp.close_edb()
 
-.. image:: ../../Resources/create_edge_port_on_polygon_and_trace.png
-..   :width: 800
-..   :alt: Edge port created on a polygon and trace
+.. image:: ../../resources/create_edge_port_on_polygon_and_trace.png
+    :width: 800
+    :alt: Edge port created on a polygon and trace

--- a/doc/source/user_guide/excitations/create_port_between_pin_and_layer.rst
+++ b/doc/source/user_guide/excitations/create_port_between_pin_and_layer.rst
@@ -35,6 +35,6 @@ This page shows how to create a port between a pin and a layer.
     edbapp.save_edb()
     edbapp.close_edb()
 
-.. image:: ../../Resources/create_port_between_pin_and_layer.png
-..   :width: 800
-..   :alt: Port created between a pin and layer
+.. image:: ../../resources/create_port_between_pin_and_layer.png
+    :width: 800
+    :alt: Port created between a pin and layer

--- a/doc/source/user_guide/layer_stackup/define_layer_stackup.rst
+++ b/doc/source/user_guide/layer_stackup/define_layer_stackup.rst
@@ -28,6 +28,6 @@ This page shows how to add a layer in the current layer stackup.
     )
     edb.close()
 
-.. image:: ../../Resources/define_layer_stackup.png
-..   :width: 800
-..   :alt: Layer added to the layer stackup
+.. image:: ../../resources/define_layer_stackup.png
+    :width: 800
+    :alt: Layer added to the layer stackup


### PR DESCRIPTION
Some path were using `Resources` in the path when the directory's name is `resources`.
This PR should fix the failing paths.