### PR TITLE
FIX: Add pandas as default dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,18 +29,17 @@ dependencies = [
     "pywin32 >= 303;platform_system=='Windows'",
     "ansys-pythonnet >= 3.1.0rc3",
     "dotnetcore2 ==3.1.23;platform_system=='Linux'",
-    "pydantic>=2.6.4,<2.8",
-    "toml == 0.10.2",
-    "Rtree >= 1.2.0",
     "numpy>=1.20.0,<2",
+    "pandas>=1.1.0,<2.3",
+    "pydantic>=2.6.4,<2.8",
+    "Rtree >= 1.2.0",
+    "toml == 0.10.2",
     ]
 
 [project.optional-dependencies]
 tests = [
     "matplotlib>=3.5.0,<3.10",
-    "numpy>=1.20.0,<2",
     "mock>=5.1.0,<5.2",
-    "pandas>=1.1.0,<2.3",
     "pytest>=7.4.0,<8.3",
     "pytest-cov>=4.0.0,<5.1",
     "pytest-xdist>=3.5.0,<3.7",
@@ -65,7 +64,6 @@ doc = [
 ]
 full = [
     "matplotlib>=3.5.0,<3.10",
-    "pandas>=1.1.0,<2.3",
 ]
 
 


### PR DESCRIPTION
Add pandas as a default dependency and reorder some dependencies in alphabetical order.

Fixes #620.