### PR TITLE
CI: Pin upload-artifact version

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -266,8 +266,9 @@ jobs:
           .venv\Scripts\Activate.ps1
           . .\doc\make.bat html
 
+      # Verify https://github.com/actions/upload-artifact/issues/591 is fixed before upgrading.
       - name: Upload HTML documentation artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.3.4
         with:
           name: documentation-html
           path: doc/_build/html
@@ -283,7 +284,8 @@ jobs:
           . .\doc\make.bat pdf
 
       - name: Upload PDF Documentation artifact
-        uses: actions/upload-artifact@v4
+        # Verify https://github.com/actions/upload-artifact/issues/591 is fixed before upgrading.
+        uses: actions/upload-artifact@v4.3.4
         with:
           name: documentation-pdf
           path: doc/_build/latex/pyedb.pdf


### PR DESCRIPTION
The latest actions/upload-artifact version broke the doc-build job in our CICD.

Until that is fixed, we should pin the action to its previous version: v4.3.4