### PR TITLE
CHORE: Update code base to use AEDT 24.2

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -253,10 +253,17 @@ jobs:
           . .venv\Scripts\Activate.ps1
           echo "PyEDB version is: $(python -c "from pyedb import __version__; print(); print(__version__)")"
 
-      - name: Install pyaedt
+      - name: Clone PyAEDT on main branch
+        uses: actions/checkout@v4
+        with:
+          repository: ansys/pyaedt
+          path: "external/pyaedt"
+          ref: "main"
+
+      - name: Install PyAEDT main branch version with its test dependencies
         run: |
           . .venv\Scripts\Activate.ps1
-          pip install pyaedt
+          pip install --no-cache-dir external/pyaedt[tests]
 
       # Use environment variable to keep the doctree and avoid redundant build for PDF pages
       - name: Create HTML documentation

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -266,8 +266,9 @@ jobs:
           .venv\Scripts\Activate.ps1
           . .\doc\make.bat html
 
+      # Verify https://github.com/actions/upload-artifact/issues/591 is fixed before upgrading.
       - name: Upload HTML documentation artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.3.4
         with:
           name: documentation-html
           path: doc/_build/html
@@ -283,7 +284,8 @@ jobs:
           . .\doc\make.bat pdf
 
       - name: Upload PDF Documentation artifact
-        uses: actions/upload-artifact@v4
+        # Verify https://github.com/actions/upload-artifact/issues/591 is fixed before upgrading.
+        uses: actions/upload-artifact@v4.3.4
         with:
           name: documentation-pdf
           path: doc/_build/latex/pyedb.pdf

--- a/doc/source/getting_started/quickcode.rst
+++ b/doc/source/getting_started/quickcode.rst
@@ -22,7 +22,7 @@ This code shows how to use PyEDB to load an existing AEDB file into memory:
 
     temp_folder = generate_unique_folder_name()
     targetfile = downloads.download_file("edb/ANSYS-HSD_V1.aedb", destination=temp_folder)
-    edbapp = Edb(edbpath=targetfile, edbversion="2024.1")
+    edbapp = Edb(edbpath=targetfile, edbversion="2024.2")
 
 Connect to EDB from a Python IDE
 --------------------------------
@@ -41,7 +41,7 @@ Explicit PyEDB declaration and error management
     from pyedb import Edb
 
     edb_file = pyedb.layout_examples.ANSYS - HSD_V1.aedb
-    edb = Edb(edbversion="2024.1", edbpath=edb_file)
+    edb = Edb(edbversion="2024.2", edbpath=edb_file)
 
 
 Variables
@@ -52,6 +52,6 @@ Variables
     from pyedb import Edb
 
     edb_file = pyedb.layout_examples.ANSYS - HSD_V1.aedb
-    edb = Edb(edbversion="2024.1", edbpath=edb_file)
+    edb = Edb(edbversion="2024.2", edbpath=edb_file)
     edb["dim"] = "1mm"  # design variable
     edb["$dim"] = "1mm"  # project variable

--- a/doc/source/user_guide/build_simulation_project/build_signal_integrity_project.rst
+++ b/doc/source/user_guide/build_simulation_project/build_signal_integrity_project.rst
@@ -16,14 +16,14 @@ This page shows how to build an signal integrity project.
     import pyedb.misc.downloads as downloads
 
     # Ansys release version
-    ansys_version = "2024.1"
+    ansys_version = "2024.2"
 
     # download and copy the layout file from examples
     temp_folder = generate_unique_folder_name()
     targetfile = downloads.download_file("edb/ANSYS-HSD_V1.aedb", destination=temp_folder)
 
     # load EDB
-    edbapp = Edb(edbpath=targetfile, edbversion="2024.1")
+    edbapp = Edb(edbpath=targetfile, edbversion="2024.2")
 
     sim_setup = edbapp.new_simulation_configuration()
     sim_setup.signal_nets = [

--- a/doc/source/user_guide/build_simulation_project/cutout.rst
+++ b/doc/source/user_guide/build_simulation_project/cutout.rst
@@ -18,14 +18,14 @@ This page shows how to clip a design based on net selection.
 
 
     # Ansys release version
-    ansys_version = "2024.1"
+    ansys_version = "2024.2"
 
     # download and copy the layout file from examples
     temp_folder = generate_unique_folder_name()
     targetfile = downloads.download_file("edb/ANSYS-HSD_V1.aedb", destination=temp_folder)
 
     # load EDB
-    edbapp = Edb(edbpath=targetfile, edbversion="2024.1")
+    edbapp = Edb(edbpath=targetfile, edbversion="2024.2")
 
     # select signal nets to evaluate the extent for clipping the layout
     signal_nets = [

--- a/doc/source/user_guide/components/create_resistor_on_pin.rst
+++ b/doc/source/user_guide/components/create_resistor_on_pin.rst
@@ -16,7 +16,7 @@ This page shows how to create a resistor boundary on pins:
 
     temp_folder = generate_unique_folder_name()
     targetfile = downloads.download_file("edb/ANSYS-HSD_V1.aedb", destination=temp_folder)
-    edbapp = Edb(edbpath=targetfile, edbversion="2024.1")
+    edbapp = Edb(edbpath=targetfile, edbversion="2024.2")
 
     pins = edbapp.components.get_pin_from_component("U1")
     resistor = edbapp.siwave.create_resistor_on_pin(pins[302], pins[10], 40, "RST4000")

--- a/doc/source/user_guide/components/create_rlc_boundary_on_pins.rst
+++ b/doc/source/user_guide/components/create_rlc_boundary_on_pins.rst
@@ -17,7 +17,7 @@ This page shows how to create an RLC boundary on pins.
     # download and open EDB project
     temp_folder = generate_unique_folder_name()
     targetfile = downloads.download_file("edb/ANSYS-HSD_V1.aedb", destination=temp_folder)
-    edbapp = Edb(edbpath=targetfile, edbversion="2024.1")
+    edbapp = Edb(edbpath=targetfile, edbversion="2024.2")
 
     # retrieve pins from ``U1`` component and ``1V0`` net
     pins = edbapp.components.get_pin_from_component("U1", "1V0")

--- a/doc/source/user_guide/components/create_rlc_component.rst
+++ b/doc/source/user_guide/components/create_rlc_component.rst
@@ -19,7 +19,7 @@ This page shows how to create an RLC component between pins:
     # download and open EDB project
     temp_folder = generate_unique_folder_name()
     targetfile = downloads.download_file("edb/ANSYS-HSD_V1.aedb", destination=temp_folder)
-    edbapp = Edb(edbpath=targetfile, edbversion="2024.1")
+    edbapp = Edb(edbpath=targetfile, edbversion="2024.2")
 
     # retrieving pins from component U1 and net 1V0
     pins = edbapp.components.get_pin_from_component("U1", "1V0")

--- a/doc/source/user_guide/edb_information_queries/edb_queries.rst
+++ b/doc/source/user_guide/edb_information_queries/edb_queries.rst
@@ -27,7 +27,7 @@ Load a layout
 
     temp_folder = generate_unique_folder_name()
     targetfile = downloads.download_file("edb/ANSYS-HSD_V1.aedb", destination=temp_folder)
-    edbapp = Edb(edbpath=targetfile, edbversion="2024.1")
+    edbapp = Edb(edbpath=targetfile, edbversion="2024.2")
 
 Get statistics
 ~~~~~~~~~~~~~~

--- a/doc/source/user_guide/edb_information_queries/get_layout_bounding_box.rst
+++ b/doc/source/user_guide/edb_information_queries/get_layout_bounding_box.rst
@@ -16,7 +16,7 @@ This tutorial shows how to retrieve the layout size by getting the bounding box.
 
     temp_folder = generate_unique_folder_name()
     targetfile = downloads.download_file("edb/ANSYS-HSD_V1.aedb", destination=temp_folder)
-    edbapp = Edb(edbpath=targetfile, edbversion="2024.1")
+    edbapp = Edb(edbpath=targetfile, edbversion="2024.2")
 
     edbapp.get_bounding_box()
 

--- a/doc/source/user_guide/excitations/create_circuit_ports_on_component.rst
+++ b/doc/source/user_guide/excitations/create_circuit_ports_on_component.rst
@@ -18,7 +18,7 @@ This page shows how to retrieve pins and create a circuit port on a component.
 
     temp_folder = generate_unique_folder_name()
     targetfile = downloads.download_file("edb/ANSYS-HSD_V1.aedb", destination=temp_folder)
-    edbapp = Edb(edbpath=targetfile, edbversion="2024.1")
+    edbapp = Edb(edbpath=targetfile, edbversion="2024.2")
 
     edbapp.siwave.create_circuit_port_on_net("U1", "1V0", "U1", "GND", 50, "test")
     edbapp.components.get_pin_from_component("U1")

--- a/doc/source/user_guide/excitations/create_coax_port_on_component.rst
+++ b/doc/source/user_guide/excitations/create_coax_port_on_component.rst
@@ -16,14 +16,14 @@ This page shows how to create an HFSS coaxial port on a component.
     import pyedb.misc.downloads as downloads
 
     # Ansys release version
-    ansys_version = "2024.1"
+    ansys_version = "2024.2"
 
     # download and copy the layout file from examples
     temp_folder = generate_unique_folder_name()
     targetfile = downloads.download_file("edb/ANSYS-HSD_V1.aedb", destination=temp_folder)
 
     # load EDB
-    edbapp = Edb(edbpath=targetfile, edbversion="2024.1")
+    edbapp = Edb(edbpath=targetfile, edbversion="2024.2")
 
     edbapp.hfss.create_coax_port_on_component("U1", ["DDR4_DQS0_P", "DDR4_DQS0_N"])
     edbapp.save_edb()

--- a/doc/source/user_guide/excitations/create_current_source.rst
+++ b/doc/source/user_guide/excitations/create_current_source.rst
@@ -18,7 +18,7 @@ This page shows how to create current and voltage sources on a component.
 
     temp_folder = generate_unique_folder_name()
     targetfile = downloads.download_file("edb/ANSYS-HSD_V1.aedb", destination=temp_folder)
-    edbapp = Edb(edbpath=targetfile, edbversion="2024.1")
+    edbapp = Edb(edbpath=targetfile, edbversion="2024.2")
 
     # create simple current source on ``U1`` component between ``USB3_D_N`` and ``GND`` nets
     edbapp.siwave.create_current_source_on_net("U1", "USB3_D_N", "U1", "GND", 0.1, 0) != ""

--- a/doc/source/user_guide/excitations/create_edge_port_on_polygon.rst
+++ b/doc/source/user_guide/excitations/create_edge_port_on_polygon.rst
@@ -16,14 +16,14 @@ This page shows how to create an edge port on a polygon and trace.
     import pyedb.misc.downloads as downloads
 
     # Ansys release version
-    ansys_version = "2024.1"
+    ansys_version = "2024.2"
 
     # download and copy the layout file from examples
     temp_folder = generate_unique_folder_name()
     targetfile = downloads.download_file("edb/edb_edge_ports.aedb", destination=temp_folder)
 
     # load EDB
-    edbapp = Edb(edbpath=targetfile, edbversion="2024.1")
+    edbapp = Edb(edbpath=targetfile, edbversion="2024.2")
 
     # retrieve polygon list
     poly_list = [

--- a/doc/source/user_guide/excitations/create_port_between_pin_and_layer.rst
+++ b/doc/source/user_guide/excitations/create_port_between_pin_and_layer.rst
@@ -15,14 +15,14 @@ This page shows how to create a port between a pin and a layer.
     import pyedb.misc.downloads as downloads
 
     # Ansys release version
-    ansys_version = "2024.1"
+    ansys_version = "2024.2"
 
     # download and copy the layout file from examples
     temp_folder = generate_unique_folder_name()
     targetfile = downloads.download_file("edb/ANSYS-HSD_V1.aedb", destination=temp_folder)
 
     # load EDB
-    edbapp = Edb(edbpath=targetfile, edbversion="2024.1")
+    edbapp = Edb(edbpath=targetfile, edbversion="2024.2")
 
     edbapp.siwave.create_port_between_pin_and_layer(
         component_name="U1", pins_name="A27", layer_name="16_Bottom", reference_net="GND"

--- a/doc/source/user_guide/layer_stackup/layer_stackup.rst
+++ b/doc/source/user_guide/layer_stackup/layer_stackup.rst
@@ -16,7 +16,7 @@ This page shows how edit a layer in the current layer stackup.
 
     temp_folder = generate_unique_folder_name()
     targetfile = downloads.download_file("edb/ANSYS-HSD_V1.aedb", destination=temp_folder)
-    edbapp = Edb(edbpath=targetfile, edbversion="2024.1")
+    edbapp = Edb(edbpath=targetfile, edbversion="2024.2")
 
     # plot layer stackup in Matplotlib
     edbapp.stackup.plot()

--- a/doc/source/user_guide/load_export_edb/loading_layout.rst
+++ b/doc/source/user_guide/load_export_edb/loading_layout.rst
@@ -19,7 +19,7 @@ start manipulating objects.
 
     temp_folder = generate_unique_folder_name()
     targetfile = downloads.download_file("edb/ANSYS-HSD_V1.aedb", destination=temp_folder)
-    edbapp = Edb(edbpath=targetfile, edbversion="2024.1")
+    edbapp = Edb(edbpath=targetfile, edbversion="2024.2")
 
 .. image:: ../../resources/starting_load_edb.png
   :width: 600

--- a/doc/source/user_guide/padstacks/set_all_antipads_value.rst
+++ b/doc/source/user_guide/padstacks/set_all_antipads_value.rst
@@ -15,14 +15,14 @@ This page shows how to edit a padstack definition, setting all anti-pad values t
     import pyedb.misc.downloads as downloads
 
     # Ansys release version
-    ansys_version = "2024.1"
+    ansys_version = "2024.2"
 
     # download and copy the layout file from examples
     temp_folder = generate_unique_folder_name()
     targetfile = downloads.download_file("edb/ANSYS-HSD_V1.aedb", destination=temp_folder)
 
     # load EDB
-    edbapp = Edb(edbpath=targetfile, edbversion="2024.1")
+    edbapp = Edb(edbpath=targetfile, edbversion="2024.2")
 
     # sets all anti-pads value to zero
     edbapp.padstacks.set_all_antipad_value(0.0)

--- a/doc/source/user_guide/simulation_setup/add_siwave_analysis.rst
+++ b/doc/source/user_guide/simulation_setup/add_siwave_analysis.rst
@@ -16,7 +16,7 @@ This page shows how to create and set up a SIwave SYZ analysis.
 
     temp_folder = generate_unique_folder_name()
     targetfile = downloads.download_file("edb/ANSYS-HSD_V1.aedb", destination=temp_folder)
-    edbapp = Edb(edbpath=targetfile, edbversion="2024.1")
+    edbapp = Edb(edbpath=targetfile, edbversion="2024.2")
 
     # Add SIwave SYZ analysis
     edbapp.siwave.add_siwave_syz_analysis(

--- a/doc/source/user_guide/simulation_setup/define_hfss_simulation_setup.rst
+++ b/doc/source/user_guide/simulation_setup/define_hfss_simulation_setup.rst
@@ -15,14 +15,14 @@ This page shows how to set up an HFSS simulation.
     import pyedb.misc.downloads as downloads
 
     # Ansys release version
-    ansys_version = "2024.1"
+    ansys_version = "2024.2"
 
     # download and copy the layout file from examples
     temp_folder = generate_unique_folder_name()
     targetfile = downloads.download_file("edb/ANSYS-HSD_V1.aedb", destination=temp_folder)
 
     # load EDB
-    edbapp = Edb(edbpath=targetfile, edbversion="2024.1")
+    edbapp = Edb(edbpath=targetfile, edbversion="2024.2")
 
     # create HFSS simulation setup
     setup1 = edbapp.create_hfss_setup("setup1")

--- a/doc/source/user_guide/use_design_variables.rst
+++ b/doc/source/user_guide/use_design_variables.rst
@@ -16,7 +16,7 @@ This page shows how to define design variables for use by EDB.
 
     temp_folder = generate_unique_folder_name()
     targetfile = downloads.download_file("edb/ANSYS-HSD_V1.aedb", destination=temp_folder)
-    edbapp = Edb(edbpath=targetfile, edbversion="2024.1")
+    edbapp = Edb(edbpath=targetfile, edbversion="2024.2")
 
     # adding design variable
     edbapp.add_design_variable("my_variable", "1mm")

--- a/examples/legacy_pyaedt_integration/03_5G_antenna_example.py
+++ b/examples/legacy_pyaedt_integration/03_5G_antenna_example.py
@@ -94,7 +94,7 @@ class LinearArray:
 tmpfold = tempfile.gettempdir()
 aedb_path = os.path.join(tmpfold, generate_unique_name("pcb") + ".aedb")
 print(aedb_path)
-edb = pyedb.Edb(edbpath=aedb_path, edbversion="2024.1")
+edb = pyedb.Edb(edbpath=aedb_path, edbversion="2024.2")
 
 # ## Add stackup layers
 #
@@ -226,7 +226,7 @@ print("EDB saved correctly to {}. You can import in AEDT.".format(aedb_path))
 # Launch HFSS 3D Layout and open EDB.
 
 h3d = Hfss3dLayout(
-    projectname=aedb_path, specified_version="2024.1", new_desktop_session=True, non_graphical=non_graphical
+    projectname=aedb_path, specified_version="2024.2", new_desktop_session=True, non_graphical=non_graphical
 )
 
 # ## Plot geometry

--- a/examples/legacy_pyaedt_integration/03_5G_antenna_example_parametrics.py
+++ b/examples/legacy_pyaedt_integration/03_5G_antenna_example_parametrics.py
@@ -87,8 +87,8 @@ class LinearArray:
 temp_dir = tempfile.TemporaryDirectory(suffix=".ansys")
 aedb_path = os.path.join(temp_dir.name, "linear_array.aedb")
 
-# Select EDB version (change it manually if needed, e.g. "2024.1")
-edb_version = "2024.1"
+# Select EDB version (change it manually if needed, e.g. "2024.2")
+edb_version = "2024.2"
 print(f"EDB version: {edb_version}")
 
 # Create an instance of the Edb class.
@@ -246,7 +246,7 @@ print("EDB saved correctly to {}. You can import in AEDT.".format(aedb_path))
 h3d = pyaedt.Hfss(
     projectname="Demo_3DComp",
     designname="Linear_Array",
-    specified_version="2024.1",
+    specified_version="2024.2",
     new_desktop_session=True,
     non_graphical=non_graphical,
     close_on_exit=True,

--- a/examples/legacy_pyaedt_integration/04_edb_parametrized_design.py
+++ b/examples/legacy_pyaedt_integration/04_edb_parametrized_design.py
@@ -206,20 +206,27 @@ for n in range(len(points_p)):
 
 # Create the wave ports
 
-edb.hfss.create_differential_wave_port(
+p1 = edb.hfss.create_differential_wave_port(
     trace_p[0].id,
     ["0.0", "($ms_width+$ms_spacing)/2"],
     trace_n[0].id,
     ["0.0", "-($ms_width+$ms_spacing)/2"],
     "wave_port_1",
 )
-edb.hfss.create_differential_wave_port(
+
+pos_p1 = p1[1].terminals[0].name
+neg_p1 = p1[1].terminals[1].name
+
+p2 = edb.hfss.create_differential_wave_port(
     trace_p[2].id,
     ["$pcb_len", "($ms_width+$ms_spacing)/2"],
     trace_n[2].id,
     ["$pcb_len", "-($ms_width + $ms_spacing)/2"],
     "wave_port_2",
 )
+
+pos_p2 = p2[1].terminals[0].name
+neg_p2 = p2[1].terminals[1].name
 
 # Draw a conducting rectangle on the ground layers.
 
@@ -287,10 +294,10 @@ edb.close_edb()
 # Open the project in HFSS 3D Layout.
 
 h3d = pyaedt.Hfss3dLayout(
-    projectname=aedb_path,
-    specified_version="2024.2",
+    project=aedb_path,
+    version=edb_version,
     non_graphical=non_graphical,
-    new_desktop_session=True,
+    new_desktop=True,
 )
 
 # ## Add HFSS simulation setup
@@ -302,12 +309,12 @@ setup = h3d.create_setup()
 setup.props["AdaptiveSettings"]["SingleFrequencyDataList"]["AdaptiveFrequencyData"]["MaxPasses"] = 3
 
 h3d.create_linear_count_sweep(
-    setupname=setup.name,
+    setup=setup.name,
     unit="GHz",
-    freqstart=0,
-    freqstop=10,
+    start_frequency=0,
+    stop_frequency=10,
     num_of_freq_points=1001,
-    sweepname="sweep1",
+    name="sweep1",
     sweep_type="Interpolating",
     interpolation_tol_percent=1,
     interpolation_max_solutions=255,
@@ -319,8 +326,8 @@ h3d.create_linear_count_sweep(
 # Define the differential pairs to used to calculate differential and common mode
 # s-parameters.
 
-h3d.set_differential_pair(diff_name="In", positive_terminal="wave_port_1:T1", negative_terminal="wave_port_1:T2")
-h3d.set_differential_pair(diff_name="Out", positive_terminal="wave_port_2:T1", negative_terminal="wave_port_2:T2")
+h3d.set_differential_pair(differential_mode="In", assignment=pos_p1, reference=neg_p1)
+h3d.set_differential_pair(differential_mode="Out", assignment=pos_p2, reference=neg_p2)
 
 # Solve the project.
 

--- a/examples/legacy_pyaedt_integration/04_edb_parametrized_design.py
+++ b/examples/legacy_pyaedt_integration/04_edb_parametrized_design.py
@@ -33,8 +33,8 @@ non_graphical = False
 temp_dir = tempfile.TemporaryDirectory(suffix=".ansys")
 aedb_path = os.path.join(temp_dir.name, "pcb.aedb")
 
-# Select EDB version (change it manually if needed, e.g. "2024.1")
-edb_version = "2024.1"
+# Select EDB version (change it manually if needed, e.g. "2024.2")
+edb_version = "2024.2"
 print(f"EDB version: {edb_version}")
 
 edb = pyedb.Edb(edbpath=aedb_path, edbversion=edb_version)
@@ -288,7 +288,7 @@ edb.close_edb()
 
 h3d = pyaedt.Hfss3dLayout(
     projectname=aedb_path,
-    specified_version="2024.1",
+    specified_version="2024.2",
     non_graphical=non_graphical,
     new_desktop_session=True,
 )

--- a/examples/legacy_pyaedt_integration/09_Configuration.py
+++ b/examples/legacy_pyaedt_integration/09_Configuration.py
@@ -32,8 +32,8 @@ print("Project folder is", target_aedb)
 # Launch the ``pyedb.Edb`` class using EDB 2023 R2. Length units are SI.
 
 # +
-# Select EDB version (change it manually if needed, e.g. "2024.1")
-edb_version = "2024.1"
+# Select EDB version (change it manually if needed, e.g. "2024.2")
+edb_version = "2024.2"
 print(f"EDB version: {edb_version}")
 
 edbapp = pyedb.Edb(target_aedb, edbversion=edb_version)

--- a/examples/legacy_pyaedt_integration/12_edb_sma_connector_on_board.py
+++ b/examples/legacy_pyaedt_integration/12_edb_sma_connector_on_board.py
@@ -30,8 +30,8 @@ from pyedb.misc.downloads import download_file
 temp_dir = tempfile.TemporaryDirectory(suffix=".ansys")
 working_folder = temp_dir.name
 
-# Select EDB version (change it manually if needed, e.g. "2024.1")
-edb_version = "2024.1"
+# Select EDB version (change it manually if needed, e.g. "2024.2")
+edb_version = "2024.2"
 print(f"EDB version: {edb_version}")
 
 aedb_path = os.path.join(working_folder, "pcb.aedb")

--- a/examples/legacy_pyaedt_integration/13_edb_create_component.py
+++ b/examples/legacy_pyaedt_integration/13_edb_create_component.py
@@ -38,8 +38,8 @@ from pyedb import Edb
 temp_dir = tempfile.TemporaryDirectory(suffix=".ansys")
 aedb_path = os.path.join(temp_dir.name, "component_example.aedb")
 
-# Select EDB version (change it manually if needed, e.g. "2024.1")
-edb_version = "2024.1"
+# Select EDB version (change it manually if needed, e.g. "2024.2")
+edb_version = "2024.2"
 print(f"EDB version: {edb_version}")
 
 edb = Edb(edbpath=aedb_path, edbversion=edb_version)
@@ -225,7 +225,7 @@ edb.build_simulation_project(sim_setup)
 edb.save_edb()
 edb.close_edb()
 h3d = pyaedt.Hfss3dLayout(
-    specified_version="2024.1",
+    specified_version="2024.2",
     projectname=aedb_path,
     non_graphical=False,  # Set non_graphical = False to launch AEDT in graphical mode.
     new_desktop_session=True,

--- a/examples/legacy_pyaedt_integration/14_edb_create_parametrized_design.py
+++ b/examples/legacy_pyaedt_integration/14_edb_create_parametrized_design.py
@@ -25,8 +25,8 @@ temp_dir = tempfile.TemporaryDirectory(suffix=".ansys")
 target_aedb = download_file("edb/ANSYS-HSD_V1.aedb", destination=temp_dir.name)
 print("Project is located in ", target_aedb)
 
-# Select EDB version (change it manually if needed, e.g. "2024.1")
-edb_version = "2024.1"
+# Select EDB version (change it manually if needed, e.g. "2024.2")
+edb_version = "2024.2"
 print(f"EDB version: {edb_version}")
 
 edb = pyedb.Edb(edbpath=target_aedb, edbversion=edb_version)

--- a/examples/legacy_pyaedt_integration/15_ac_analysis.py
+++ b/examples/legacy_pyaedt_integration/15_ac_analysis.py
@@ -36,8 +36,8 @@ print(edb_full_path)
 # Create an instance of the ``pyedb.Edb`` class.
 
 # +
-# Select EDB version (change it manually if needed, e.g. "2024.1")
-edb_version = "2024.1"
+# Select EDB version (change it manually if needed, e.g. "2024.2")
+edb_version = "2024.2"
 print(f"EDB version: {edb_version}")
 
 edbapp = pyedb.Edb(edbpath=edb_full_path, edbversion=edb_version)
@@ -140,7 +140,7 @@ edbapp.close_edb()
 
 h3d = pyaedt.Hfss3dLayout(
     edb_full_path,
-    specified_version="2024.1",
+    specified_version="2024.2",
     non_graphical=False,  # Set to true for non-graphical mode.
     new_desktop_session=True,
 )

--- a/examples/legacy_standalone/00_EDB_Create_VIA.py
+++ b/examples/legacy_standalone/00_EDB_Create_VIA.py
@@ -18,8 +18,8 @@ temp_dir = tempfile.TemporaryDirectory(suffix=".ansys")
 aedb_path = os.path.join(temp_dir.name, "create_via.aedb")
 print(f"AEDB file path: {aedb_path}")
 
-# Select EDB version (change it manually if needed, e.g. "2024.1")
-edb_version = "2024.1"
+# Select EDB version (change it manually if needed, e.g. "2024.2")
+edb_version = "2024.2"
 print(f"EDB version: {edb_version}")
 
 edb = pyedb.Edb(edbpath=aedb_path, edbversion=edb_version)

--- a/examples/legacy_standalone/01_edb_example.py
+++ b/examples/legacy_standalone/01_edb_example.py
@@ -28,8 +28,8 @@ aedt_file = targetfile[:-4] + "aedt"
 if os.path.exists(aedt_file):
     os.remove(aedt_file)
 
-# Select EDB version (change it manually if needed, e.g. "2024.1")
-edb_version = "2024.1"
+# Select EDB version (change it manually if needed, e.g. "2024.2")
+edb_version = "2024.2"
 print(f"EDB version: {edb_version}")
 
 edb = pyedb.Edb(edbpath=targetfile, edbversion=edb_version)
@@ -193,7 +193,7 @@ edb.close_edb()
 # using the SIwave user interface. This command works on Window OS only.
 
 # +
-# siwave = pyedb.Siwave("2024.1")
+# siwave = pyedb.Siwave("2024.2")
 # siwave.open_project(siwave_file)
 # report_file = os.path.join(temp_folder,'Ansys.htm')
 

--- a/examples/legacy_standalone/02_edb_to_ipc2581.py
+++ b/examples/legacy_standalone/02_edb_to_ipc2581.py
@@ -27,8 +27,8 @@ print(targetfile)
 # > Note that length dimensions passed to EDB are in SI units.
 
 # +
-# Select EDB version (change it manually if needed, e.g. "2024.1")
-edb_version = "2024.1"
+# Select EDB version (change it manually if needed, e.g. "2024.2")
+edb_version = "2024.2"
 print(f"EDB version: {edb_version}")
 
 edb = pyedb.Edb(edbpath=targetfile, edbversion=edb_version)

--- a/examples/legacy_standalone/03_rename_nets_and_ports.py
+++ b/examples/legacy_standalone/03_rename_nets_and_ports.py
@@ -40,9 +40,9 @@ temp_folder = generate_unique_folder_name()
 targetfile = downloads.download_file("edb/ANSYS-HSD_V1.aedb", destination=temp_folder)
 
 # ## opening EDB
-# Opening EDB with ANSYS release 2024.1
+# Opening EDB with ANSYS release 2024.2
 
-EDB_VERSION = "2024.1"
+EDB_VERSION = "2024.2"
 edbapp = Edb(edbpath=targetfile, edbversion=EDB_VERSION)
 
 # ## Renaming all signal nets

--- a/examples/legacy_standalone/05_Plot_nets.py
+++ b/examples/legacy_standalone/05_Plot_nets.py
@@ -27,8 +27,8 @@ targetfolder = download_file("edb/ANSYS-HSD_V1.aedb", destination=temp_dir.name)
 # > Note that units are SI.
 
 # +
-# Select EDB version (change it manually if needed, e.g. "2024.1")
-edb_version = "2024.1"
+# Select EDB version (change it manually if needed, e.g. "2024.2")
+edb_version = "2024.2"
 print(f"EDB version: {edb_version}")
 
 edb = pyedb.Edb(edbpath=targetfolder, edbversion=edb_version)

--- a/examples/legacy_standalone/06_Advanced_EDB.py
+++ b/examples/legacy_standalone/06_Advanced_EDB.py
@@ -37,8 +37,8 @@ def create_ground_planes(edb, layers):
 # If the path doesn't exist, PyEDB automatically generates a new AEDB folder.
 
 # +
-# Select EDB version (change it manually if needed, e.g. "2024.1")
-edb_version = "2024.1"
+# Select EDB version (change it manually if needed, e.g. "2024.2")
+edb_version = "2024.2"
 print(f"EDB version: {edb_version}")
 
 edb = pyedb.Edb(edbpath=aedb_path, edbversion=edb_version)

--- a/examples/legacy_standalone/08_CPWG.py
+++ b/examples/legacy_standalone/08_CPWG.py
@@ -32,8 +32,8 @@ non_graphical = False
 aedb_path = os.path.join(generate_unique_folder_name(), generate_unique_name("pcb") + ".aedb")
 print(aedb_path)
 
-# Select EDB version (change it manually if needed, e.g. "2024.1")
-edb_version = "2024.1"
+# Select EDB version (change it manually if needed, e.g. "2024.2")
+edb_version = "2024.2"
 print(f"EDB version: {edb_version}")
 aedt_version = edb_version
 

--- a/examples/legacy_standalone/10_GDS_workflow.py
+++ b/examples/legacy_standalone/10_GDS_workflow.py
@@ -94,8 +94,8 @@ c.write_xml(os.path.join(temp_dir.name, "output.xml"))
 # Import the gds and open the edb.
 
 # +
-# Select EDB version (change it manually if needed, e.g. "2024.1")
-edb_version = "2024.1"
+# Select EDB version (change it manually if needed, e.g. "2024.2")
+edb_version = "2024.2"
 print(f"EDB version: {edb_version}")
 
 edb = pyedb.Edb(gds_out, edbversion=edb_version, technology_file=os.path.join(temp_dir.name, "output.xml"))

--- a/examples/legacy_standalone/11_post_layout_parameterization.py
+++ b/examples/legacy_standalone/11_post_layout_parameterization.py
@@ -23,8 +23,8 @@ temp_dir = tempfile.TemporaryDirectory(suffix=".ansys")
 
 edb_path = download_file("edb/ANSYS-HSD_V1.aedb", destination=temp_dir.name)
 
-# Select EDB version (change it manually if needed, e.g. "2024.1")
-edb_version = "2024.1"
+# Select EDB version (change it manually if needed, e.g. "2024.2")
+edb_version = "2024.2"
 print(f"EDB version: {edb_version}")
 
 edb = pyedb.Edb(edb_path, edbversion=edb_version)

--- a/examples/use_configuration/import_material.py
+++ b/examples/use_configuration/import_material.py
@@ -14,7 +14,7 @@ from pyaedt.downloads import download_file
 
 from pyedb import Edb
 
-AEDT_VERSION = "2024.1"
+AEDT_VERSION = "2024.2"
 NG_MODE = False
 
 # -

--- a/examples/use_configuration/import_ports.py
+++ b/examples/use_configuration/import_ports.py
@@ -22,7 +22,7 @@ from pyaedt.downloads import download_file
 
 from pyedb import Edb
 
-AEDT_VERSION = "2024.1"
+AEDT_VERSION = "2024.2"
 NG_MODE = False
 
 # -

--- a/examples/use_configuration/import_setup_ac.py
+++ b/examples/use_configuration/import_setup_ac.py
@@ -16,7 +16,7 @@ from pyaedt.downloads import download_file
 
 from pyedb import Edb
 
-AEDT_VERSION = "2024.1"
+AEDT_VERSION = "2024.2"
 NG_MODE = False
 
 # -

--- a/examples/use_configuration/import_stackup.py
+++ b/examples/use_configuration/import_stackup.py
@@ -14,7 +14,7 @@ from pyaedt.downloads import download_file
 
 from pyedb import Edb
 
-AEDT_VERSION = "2024.1"
+AEDT_VERSION = "2024.2"
 NG_MODE = False
 
 # -

--- a/examples/use_configuration/set_up_edb_for_signal_integrity_analysis.py
+++ b/examples/use_configuration/set_up_edb_for_signal_integrity_analysis.py
@@ -15,7 +15,7 @@ from pyaedt.downloads import download_file
 
 from pyedb import Edb
 
-AEDT_VERSION = "2024.1"
+AEDT_VERSION = "2024.2"
 NG_MODE = False
 
 # -

--- a/src/pyedb/dotnet/edb_core/cell/terminal/bundle_terminal.py
+++ b/src/pyedb/dotnet/edb_core/cell/terminal/bundle_terminal.py
@@ -43,10 +43,6 @@ class BundleTerminal(Terminal):
         """Get terminals belonging to this excitation."""
         return [EdgeTerminal(self._pedb, i) for i in list(self._edb_object.GetTerminals())]
 
-    @property
-    def name(self):
-        return self.terminals[0].name
-
     def decouple(self):
         """Ungroup a bundle of terminals."""
         return self._edb_object.Ungroup()

--- a/src/pyedb/dotnet/edb_core/cell/terminal/edge_terminal.py
+++ b/src/pyedb/dotnet/edb_core/cell/terminal/edge_terminal.py
@@ -47,4 +47,4 @@ class EdgeTerminal(Terminal):
         temp.extend([i._edb_object for i in port])
         edb_list = convert_py_list_to_net_list(temp, self._edb.cell.terminal.Terminal)
         _edb_bundle_terminal = self._edb.cell.terminal.BundleTerminal.Create(edb_list)
-        return self._pedb.ports[self.name]
+        return self._pedb.ports[_edb_bundle_terminal.GetName()]

--- a/src/pyedb/dotnet/edb_core/edb_data/primitives_data.py
+++ b/src/pyedb/dotnet/edb_core/edb_data/primitives_data.py
@@ -1160,7 +1160,7 @@ class EDBArcs(object):
 
         Examples
         --------
-        >>> appedb = Edb(fpath, edbversion="2024.1")
+        >>> appedb = Edb(fpath, edbversion="2024.2")
         >>> start_coordinate = appedb.nets["V1P0_S0"].primitives[0].arcs[0].start
         >>> print(start_coordinate)
         [x_value, y_value]
@@ -1179,7 +1179,7 @@ class EDBArcs(object):
 
         Examples
         --------
-        >>> appedb = Edb(fpath, edbversion="2024.1")
+        >>> appedb = Edb(fpath, edbversion="2024.2")
         >>> end_coordinate = appedb.nets["V1P0_S0"].primitives[0].arcs[0].end
         """
         point = self.arc_object.End
@@ -1197,7 +1197,7 @@ class EDBArcs(object):
 
         Examples
         --------
-        >>> appedb = Edb(fpath, edbversion="2024.1")
+        >>> appedb = Edb(fpath, edbversion="2024.2")
         >>> arc_height = appedb.nets["V1P0_S0"].primitives[0].arcs[0].height
         """
         return self.arc_object.Height

--- a/src/pyedb/dotnet/edb_core/hfss.py
+++ b/src/pyedb/dotnet/edb_core/hfss.py
@@ -549,8 +549,8 @@ class EdbHfss(object):
         _edb_boundle_terminal = self._edb.cell.terminal.BundleTerminal.Create(edb_list)
         _edb_boundle_terminal.SetName(port_name)
         pos, neg = list(_edb_boundle_terminal.GetTerminals())
-        pos.SetName(port_name+":T1")
-        neg.SetName(port_name+":T2")
+        pos.SetName(port_name + ":T1")
+        neg.SetName(port_name + ":T2")
         return port_name, BundleWavePort(self._pedb, _edb_boundle_terminal)
 
     def create_bundle_wave_port(

--- a/src/pyedb/dotnet/edb_core/hfss.py
+++ b/src/pyedb/dotnet/edb_core/hfss.py
@@ -547,12 +547,10 @@ class EdbHfss(object):
             [pos_term._edb_object, neg_term._edb_object], self._edb.cell.terminal.Terminal
         )
         _edb_boundle_terminal = self._edb.cell.terminal.BundleTerminal.Create(edb_list)
-        if float(self._pedb.edbversion) > 2024.1:
-            pos, neg = list(_edb_boundle_terminal.GetTerminals())
-            pos.SetName(port_name+":T1")
-            neg.SetName(port_name+":T2")
-        else:
-            pos_term._edb_object.SetName(port_name)
+        _edb_boundle_terminal.SetName(port_name)
+        pos, neg = list(_edb_boundle_terminal.GetTerminals())
+        pos.SetName(port_name+":T1")
+        neg.SetName(port_name+":T2")
         return port_name, BundleWavePort(self._pedb, _edb_boundle_terminal)
 
     def create_bundle_wave_port(

--- a/src/pyedb/dotnet/edb_core/hfss.py
+++ b/src/pyedb/dotnet/edb_core/hfss.py
@@ -547,11 +547,12 @@ class EdbHfss(object):
             [pos_term._edb_object, neg_term._edb_object], self._edb.cell.terminal.Terminal
         )
         _edb_boundle_terminal = self._edb.cell.terminal.BundleTerminal.Create(edb_list)
-
-        pos_port_name = port_name + ":T1"
-        pos_term._edb_object.SetName(pos_port_name)
-        neg_port_name = port_name + ":T2"
-        neg_term._edb_object.SetName(neg_port_name)
+        if float(self._pedb.edbversion) > 2024.1:
+            pos, neg = list(_edb_boundle_terminal.GetTerminals())
+            pos.SetName(port_name+":T1")
+            neg.SetName(port_name+":T2")
+        else:
+            pos_term._edb_object.SetName(port_name)
         return port_name, BundleWavePort(self._pedb, _edb_boundle_terminal)
 
     def create_bundle_wave_port(

--- a/src/pyedb/dotnet/edb_core/hfss.py
+++ b/src/pyedb/dotnet/edb_core/hfss.py
@@ -547,8 +547,11 @@ class EdbHfss(object):
             [pos_term._edb_object, neg_term._edb_object], self._edb.cell.terminal.Terminal
         )
         _edb_boundle_terminal = self._edb.cell.terminal.BundleTerminal.Create(edb_list)
-        # _edb_boundle_terminal.SetName("Wave_"+port_name)
-        pos_term._edb_object.SetName(port_name)
+
+        pos_port_name = port_name + ":T1"
+        pos_term._edb_object.SetName(pos_port_name)
+        neg_port_name = port_name + ":T2"
+        neg_term._edb_object.SetName(neg_port_name)
         return port_name, BundleWavePort(self._pedb, _edb_boundle_terminal)
 
     def create_bundle_wave_port(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,7 +56,7 @@ logger = pyedb_logger
 local_path = os.path.dirname(os.path.realpath(__file__))
 
 # Initialize default desktop configuration
-desktop_version = "2024.1"
+desktop_version = "2024.2"
 if "ANSYSEM_ROOT{}".format(desktop_version[2:].replace(".", "")) not in list_installed_ansysem():
     desktop_version = list_installed_ansysem()[0][12:].replace(".", "")
     desktop_version = "20{}.{}".format(desktop_version[:2], desktop_version[-1])

--- a/tests/legacy/system/conftest.py
+++ b/tests/legacy/system/conftest.py
@@ -36,7 +36,7 @@ from tests.conftest import generate_random_string
 example_models_path = os.path.join(dirname(dirname(dirname(os.path.realpath(__file__)))), "example_models")
 
 # Initialize default desktop configuration
-desktop_version = "2024.1"
+desktop_version = "2024.2"
 if "ANSYSEM_ROOT{}".format(desktop_version[2:].replace(".", "")) not in list_installed_ansysem():
     desktop_version = list_installed_ansysem()[0][12:].replace(".", "")
     desktop_version = "20{}.{}".format(desktop_version[:2], desktop_version[-1])

--- a/tests/legacy/system/test_edb.py
+++ b/tests/legacy/system/test_edb.py
@@ -682,7 +682,7 @@ class TestClass:
         assert port_hori.ref_terminal
 
         kwargs = {
-            "layer_name": "1_Top",
+            "layer_name": "Top",
             "net_name": "SIGP",
             "width": "0.1mm",
             "start_cap_style": "Flat",
@@ -713,15 +713,17 @@ class TestClass:
         wave_port.do_renormalize = False
         assert not wave_port.do_renormalize
         assert edb.hfss.create_differential_wave_port(
-            traces[0].id,
-            trace_paths[0][0],
             traces[1].id,
+            trace_paths[0][0],
+            traces[2].id,
             trace_paths[1][0],
             horizontal_extent_factor=8,
             port_name="df_port",
         )
         assert edb.ports["df_port"]
         p, n = edb.ports["df_port"].terminals
+        assert p.name == "df_port:T1"
+        assert n.name == "df_port:T2"
         assert edb.ports["df_port"].decouple()
         p.couple_ports(n)
 


### PR DESCRIPTION
Upgrading our code base to use AEDT 24.2 as default version.

@svandenb-dev @ring630 One of the changes that was performed comes from the fix of @Samuelopez-ansys in [68b393a](https://github.com/ansys/pyedb/pull/713/commits/68b393a08d45f89ad3a843cad939ce52b1ac3eee) It seems that AEDT 24.2 has changed the way it works with waveport naming. Previously, it changed the name on the fly and it is not the case anymore with 24.2. The fix consists in mocking what was performed previously with the naming so that 24.1 and 24.2 are both working !