### PR TITLE
DOCS: Fix doc style

### DIFF
--- a/doc/.vale.ini
+++ b/doc/.vale.ini
@@ -30,3 +30,15 @@ BasedOnStyles = Vale, Google
 # Removing Google-specific rule - Not applicable under some circumstances
 Google.WordList = NO
 Google.Colons = NO
+
+# Removing Google-specific rule - Update severity level to error on rules with default warnings
+# This should prevent external users and dependabot to be the only one having code-style action failing
+Google.Ellipses = error
+Google.FirstPerson = error
+Google.Headings = error
+Google.HeadingPunctuation = error
+Google.OxfordComma = error
+Google.Spelling = error
+Google.We = error
+Google.Will = error
+Google.WordList = error

--- a/doc/source/api/SimulationConfigurationV2.rst
+++ b/doc/source/api/SimulationConfigurationV2.rst
@@ -1,4 +1,4 @@
-Simulation configuration V2.0
+Simulation configuration v2.0
 =============================
 These classes are the containers of simulation configuration constructors V2.0 for the EDB.
 

--- a/doc/source/api/XmlControlFile.rst
+++ b/doc/source/api/XmlControlFile.rst
@@ -1,4 +1,4 @@
-XML Control File
+XML control file
 ================
 Convert a technology file to edb control file.
 

--- a/doc/source/api/edb_data/HfssExtentInfo.rst
+++ b/doc/source/api/edb_data/HfssExtentInfo.rst
@@ -1,4 +1,4 @@
-HFSS Extent Info
+HFSS extent info
 ================
 These class is the containers of HFSS Extent.
 

--- a/doc/source/api/edb_data/Utilities.rst
+++ b/doc/source/api/edb_data/Utilities.rst
@@ -1,4 +1,4 @@
-EDB Utilities
+EDB utilities
 =============
 Class managing EDB utilities.
 

--- a/doc/source/api/edb_data/index.rst
+++ b/doc/source/api/edb_data/index.rst
@@ -1,5 +1,5 @@
 ================
-EDB DATA classes
+EDB data classes
 ================
 
 This section describes EDB data classes.

--- a/doc/source/api/sim_setup_data/data/index.rst
+++ b/doc/source/api/sim_setup_data/data/index.rst
@@ -1,5 +1,5 @@
 =====================
-Simulation Setup Data
+Simulation setup data
 =====================
 
 This section describes Simulation setup data.

--- a/doc/source/api/sim_setup_data/data/sim_setup_info.rst
+++ b/doc/source/api/sim_setup_data/data/sim_setup_info.rst
@@ -1,4 +1,4 @@
-Simulation Setup Info
+Simulation setup info
 ======================
 This class is the container of simulation setup info.
 

--- a/doc/source/api/sim_setup_data/data/simulation_settings.rst
+++ b/doc/source/api/sim_setup_data/data/simulation_settings.rst
@@ -1,4 +1,4 @@
-simulation settings
+Simulation settings
 ===================
 These classes are the containers of simulation settings.
 

--- a/doc/source/api/sim_setup_data/io/index.rst
+++ b/doc/source/api/sim_setup_data/io/index.rst
@@ -1,5 +1,5 @@
 ===================
-Simulation Setup IO
+Simulation setup IO
 ===================
 
 This section describes Simulation setup IO.

--- a/doc/styles/Vocab/ANSYS/accept.txt
+++ b/doc/styles/Vocab/ANSYS/accept.txt
@@ -13,7 +13,6 @@ codecov
 Conda
 CPython
 DC
-DC-IR
 docstring
 [Dd]ocstrings
 EDB
@@ -23,6 +22,7 @@ GDS
 HFSS
 Icepak
 IO
+IR
 IronPython
 [Ll]ayout
 matplotlib

--- a/doc/styles/Vocab/ANSYS/accept.txt
+++ b/doc/styles/Vocab/ANSYS/accept.txt
@@ -13,6 +13,7 @@ codecov
 Conda
 CPython
 DC
+DC-IR
 docstring
 [Dd]ocstrings
 EDB
@@ -21,6 +22,7 @@ GDS
 [Gg]gRPC
 HFSS
 Icepak
+IO
 IronPython
 [Ll]ayout
 matplotlib
@@ -35,6 +37,7 @@ postprocessing
 Python
 Python.NET
 Q3D
+RaptorX
 RLC
 SimulationConfiguration
 Siwave

--- a/doc/styles/Vocab/ANSYS/accept.txt
+++ b/doc/styles/Vocab/ANSYS/accept.txt
@@ -44,3 +44,4 @@ Siwave
 SYZ
 (?i)stackup(?:\s3D|s)?
 vias
+XML


### PR DESCRIPTION
This PR aims at fixing the documentation style issue that we are currently stacking on the repo.

On top of it, it will convert any new warning to the google rules as an error.
This way, we are sure that external contributors as well as dependabot won't have the CICD failing due to the code-style action while they didn't do any doc modification at all. This is related to the scope of each PR.