### PR TITLE
FIX: Replace pyaedt to ansys.aedt.core

### DIFF
--- a/examples/legacy_pyaedt_integration/03_5G_antenna_example.py
+++ b/examples/legacy_pyaedt_integration/03_5G_antenna_example.py
@@ -31,7 +31,7 @@
 import os
 import tempfile
 
-from pyaedt import Hfss3dLayout
+from ansys.aedt.core import Hfss3dLayout
 
 import pyedb
 from pyedb.generic.general_methods import generate_unique_name

--- a/examples/legacy_pyaedt_integration/03_5G_antenna_example_parametrics.py
+++ b/examples/legacy_pyaedt_integration/03_5G_antenna_example_parametrics.py
@@ -12,7 +12,7 @@
 import os
 import tempfile
 
-import pyaedt
+import ansys.aedt.core
 
 import pyedb
 
@@ -243,7 +243,7 @@ print("EDB saved correctly to {}. You can import in AEDT.".format(aedb_path))
 # It is now possible to monitor the progress in the UI as each of the following cells is executed.
 # All commands can be run without the UI by changing the value of ``non_graphical``.
 
-h3d = pyaedt.Hfss(
+h3d = ansys.aedt.core.Hfss(
     projectname="Demo_3DComp",
     designname="Linear_Array",
     specified_version="2024.2",
@@ -369,7 +369,7 @@ h3d.post.create_fieldplot_layers_nets(
 # ## Close AEDT
 #
 # After the simulation completes, the application can be released from the
-# :func:`pyaedt.Desktop.release_desktop` method.
+# :func:`ansys.aedt.core.Desktop.release_desktop` method.
 # All methods provide for saving the project before closing AEDT.
 
 h3d.save_project(os.path.join(temp_dir.name, "test_layout.aedt"))

--- a/examples/legacy_pyaedt_integration/04_edb_parametrized_design.py
+++ b/examples/legacy_pyaedt_integration/04_edb_parametrized_design.py
@@ -14,7 +14,7 @@
 import os
 import tempfile
 
-import pyaedt
+import ansys.aedt.core
 
 import pyedb
 
@@ -293,7 +293,7 @@ edb.close_edb()
 
 # Open the project in HFSS 3D Layout.
 
-h3d = pyaedt.Hfss3dLayout(
+h3d = ansys.aedt.core.Hfss3dLayout(
     project=aedb_path,
     version=edb_version,
     non_graphical=non_graphical,

--- a/examples/legacy_pyaedt_integration/09_Configuration.py
+++ b/examples/legacy_pyaedt_integration/09_Configuration.py
@@ -14,7 +14,7 @@
 import os
 import tempfile
 
-import pyaedt
+import ansys.aedt.core
 
 import pyedb
 from pyedb.misc.downloads import download_file
@@ -191,7 +191,7 @@ edbapp.close_edb()
 
 aedt_version = edb_version
 
-h3d = pyaedt.Hfss3dLayout(
+h3d = ansys.aedt.core.Hfss3dLayout(
     specified_version=aedt_version,
     projectname=target_aedb,
     non_graphical=False,

--- a/examples/legacy_pyaedt_integration/12_edb_sma_connector_on_board.py
+++ b/examples/legacy_pyaedt_integration/12_edb_sma_connector_on_board.py
@@ -18,8 +18,8 @@
 import os
 import tempfile
 
-import numpy as np
 import ansys.aedt.core
+import numpy as np
 
 import pyedb
 from pyedb.misc.downloads import download_file

--- a/examples/legacy_pyaedt_integration/12_edb_sma_connector_on_board.py
+++ b/examples/legacy_pyaedt_integration/12_edb_sma_connector_on_board.py
@@ -19,7 +19,7 @@ import os
 import tempfile
 
 import numpy as np
-import pyaedt
+import ansys.aedt.core
 
 import pyedb
 from pyedb.misc.downloads import download_file
@@ -179,7 +179,7 @@ edb.close_edb()
 
 # Launch HFSS 3D Layout.
 
-h3d = pyaedt.Hfss3dLayout(aedb_path, specified_version=edb_version, new_desktop_session=True)
+h3d = ansys.aedt.core.Hfss3dLayout(aedb_path, specified_version=edb_version, new_desktop_session=True)
 
 # Place a 3D component.
 

--- a/examples/legacy_pyaedt_integration/13_edb_create_component.py
+++ b/examples/legacy_pyaedt_integration/13_edb_create_component.py
@@ -31,7 +31,7 @@
 import os
 import tempfile
 
-import pyaedt
+import ansys.aedt.core
 
 from pyedb import Edb
 
@@ -224,7 +224,7 @@ edb.build_simulation_project(sim_setup)
 
 edb.save_edb()
 edb.close_edb()
-h3d = pyaedt.Hfss3dLayout(
+h3d = ansys.aedt.core.Hfss3dLayout(
     specified_version="2024.2",
     projectname=aedb_path,
     non_graphical=False,  # Set non_graphical = False to launch AEDT in graphical mode.

--- a/examples/legacy_pyaedt_integration/14_edb_create_parametrized_design.py
+++ b/examples/legacy_pyaedt_integration/14_edb_create_parametrized_design.py
@@ -13,7 +13,7 @@
 
 import tempfile
 
-import pyaedt
+import ansys.aedt.core
 
 import pyedb
 from pyedb.misc.downloads import download_file
@@ -76,7 +76,7 @@ edb.close_edb()
 #
 # Note that there may be some delay while AEDT is being launched.
 
-hfss = pyaedt.Hfss3dLayout(
+hfss = ansys.aedt.core.Hfss3dLayout(
     projectname=target_aedb,
     specified_version=edb_version,
     non_graphical=False,

--- a/examples/legacy_pyaedt_integration/15_ac_analysis.py
+++ b/examples/legacy_pyaedt_integration/15_ac_analysis.py
@@ -14,7 +14,7 @@
 import tempfile
 import time
 
-import pyaedt
+import ansys.aedt.core
 
 import pyedb
 from pyedb.misc.downloads import download_file
@@ -138,7 +138,7 @@ edbapp.close_edb()
 # run the analysis. AEDT 3D Layout can be used to view the model
 # if it is launched in graphical mode.
 
-h3d = pyaedt.Hfss3dLayout(
+h3d = ansys.aedt.core.Hfss3dLayout(
     edb_full_path,
     specified_version="2024.2",
     non_graphical=False,  # Set to true for non-graphical mode.

--- a/examples/legacy_standalone/08_CPWG.py
+++ b/examples/legacy_standalone/08_CPWG.py
@@ -11,8 +11,8 @@
 
 import os
 
-import numpy as np
 import ansys.aedt.core
+import numpy as np
 
 from pyedb import Edb
 from pyedb.generic.general_methods import (

--- a/examples/legacy_standalone/08_CPWG.py
+++ b/examples/legacy_standalone/08_CPWG.py
@@ -12,7 +12,7 @@
 import os
 
 import numpy as np
-import pyaedt
+import ansys.aedt.core
 
 from pyedb import Edb
 from pyedb.generic.general_methods import (
@@ -121,7 +121,7 @@ edbapp.close_edb()
 
 aedt_version = edb_version
 
-h3d = pyaedt.Hfss3dLayout(
+h3d = ansys.aedt.core.Hfss3dLayout(
     projectname=aedb_path,
     specified_version=aedt_version,
     non_graphical=non_graphical,

--- a/examples/use_configuration/import_material.py
+++ b/examples/use_configuration/import_material.py
@@ -9,8 +9,8 @@ from pathlib import Path
 import tempfile
 
 from IPython.display import display
-import pandas as pd
 from ansys.aedt.core.downloads import download_file
+import pandas as pd
 
 from pyedb import Edb
 

--- a/examples/use_configuration/import_material.py
+++ b/examples/use_configuration/import_material.py
@@ -10,7 +10,7 @@ import tempfile
 
 from IPython.display import display
 import pandas as pd
-from pyaedt.downloads import download_file
+from ansys.aedt.core.downloads import download_file
 
 from pyedb import Edb
 

--- a/examples/use_configuration/import_ports.py
+++ b/examples/use_configuration/import_ports.py
@@ -19,7 +19,7 @@ import json
 from pathlib import Path
 import tempfile
 
-from pyaedt.downloads import download_file
+from ansys.aedt.core.downloads import download_file
 
 from pyedb import Edb
 

--- a/examples/use_configuration/import_setup_ac.py
+++ b/examples/use_configuration/import_setup_ac.py
@@ -13,7 +13,7 @@ import json
 from pathlib import Path
 import tempfile
 
-from pyaedt.downloads import download_file
+from ansys.aedt.core.downloads import download_file
 
 from pyedb import Edb
 

--- a/examples/use_configuration/import_stackup.py
+++ b/examples/use_configuration/import_stackup.py
@@ -9,8 +9,8 @@ from pathlib import Path
 import tempfile
 
 from IPython.display import display
-import pandas as pd
 from ansys.aedt.core.downloads import download_file
+import pandas as pd
 
 from pyedb import Edb
 

--- a/examples/use_configuration/import_stackup.py
+++ b/examples/use_configuration/import_stackup.py
@@ -10,7 +10,7 @@ import tempfile
 
 from IPython.display import display
 import pandas as pd
-from pyaedt.downloads import download_file
+from ansys.aedt.core.downloads import download_file
 
 from pyedb import Edb
 

--- a/examples/use_configuration/set_up_edb_for_signal_integrity_analysis.py
+++ b/examples/use_configuration/set_up_edb_for_signal_integrity_analysis.py
@@ -10,8 +10,8 @@ import json
 import os
 import tempfile
 
-from pyaedt import Hfss3dLayout
-from pyaedt.downloads import download_file
+from ansys.aedt.core import Hfss3dLayout
+from ansys.aedt.core.downloads import download_file
 
 from pyedb import Edb
 

--- a/src/pyedb/dotnet/application/Variables.py
+++ b/src/pyedb/dotnet/application/Variables.py
@@ -27,7 +27,7 @@ This module is used to create and edit design and project variables in the 3D to
 
 Examples
 --------
->>> from pyaedt import Hfss
+>>> from ansys.aedt.core import Hfss
 >>> hfss = Hfss()
 >>> hfss["$d"] = "5mm"
 >>> hfss["d"] = "5mm"
@@ -415,8 +415,8 @@ class VariableManager(object):
     Examples
     --------
 
-    >>> from pyaedt.maxwell import Maxwell3d
-    >>> from pyaedt.desktop import Desktop
+    >>> from ansys.aedt.core.maxwell import Maxwell3d
+    >>> from ansys.aedt.core.desktop import Desktop
     >>> d = Desktop()
     >>> aedtapp = Maxwell3d()
 
@@ -1782,7 +1782,8 @@ class Variable(object):
                 Multiply ``'Length1'`` by unitless ``'None'``` to obtain ``'Length'``.
                 A numerical value is also considered to be unitless.
 
-        import pyaedt.generic.constants        >>> v1 = Variable("10mm")
+                >>> import ansys.aedt.core.generic.constants
+                >>> v1 = Variable("10mm")
                 >>> v2 = Variable(3)
                 >>> result_1 = v1 * v2
                 >>> result_2 = v1 * 3
@@ -1793,7 +1794,8 @@ class Variable(object):
 
                 Multiply voltage times current to obtain power.
 
-        import pyaedt.generic.constants        >>> v3 = Variable("3mA")
+                >>> import ansys.aedt.core.generic.constants
+                >>> v3 = Variable("3mA")
                 >>> v4 = Variable("40V")
                 >>> result_3 = v3 * v4
                 >>> assert result_3.numeric_value == 0.12
@@ -1836,7 +1838,7 @@ class Variable(object):
         Examples
         --------
         >>> from pyedb.dotnet.application.Variables import Variable
-        >>> import pyaedt.generic.constants
+        >>> import ansys.aedt.core.generic.constants
         >>> v1 = Variable("3mA")
         >>> v2 = Variable("10A")
         >>> result = v1 + v2
@@ -1876,7 +1878,7 @@ class Variable(object):
         Examples
         --------
 
-        >>> import pyaedt.generic.constants
+        >>> import ansys.aedt.core.generic.constants
         >>> from pyedb.dotnet.application.Variables import Variable
         >>> v3 = Variable("3mA")
         >>> v4 = Variable("10A")
@@ -1922,7 +1924,7 @@ class Variable(object):
         resolve the new units to ``"A"``.
 
         >>> from pyedb.dotnet.application.Variables import Variable
-        >>> import pyaedt.generic.constants
+        >>> import ansys.aedt.core.generic.constants
         >>> v1 = Variable("10W")
         >>> v2 = Variable("40V")
         >>> result = v1 / v2
@@ -1964,7 +1966,7 @@ class Variable(object):
         Divide a number by a variable with units ``"s"`` and automatically determine that
         the result is in ``"Hz"``.
 
-        >>> import pyaedt.generic.constants
+        >>> import ansys.aedt.core.generic.constants
         >>> from pyedb.dotnet.application.Variables import Variable
         >>> v = Variable("1s")
         >>> result = 3.0 / v

--- a/src/pyedb/dotnet/application/Variables.py
+++ b/src/pyedb/dotnet/application/Variables.py
@@ -1765,42 +1765,42 @@ class Variable(object):
     def __mul__(self, other):  # pragma: no cover
         """Multiply the variable with a number or another variable and return a new object.
 
-                Parameters
-                ----------
-                other : numbers.Number or variable
-                    Object to be multiplied.
+        Parameters
+        ----------
+        other : numbers.Number or variable
+            Object to be multiplied.
 
-                Returns
-                -------
-                type
-                    Variable.
+        Returns
+        -------
+        type
+            Variable.
 
-                Examples
-                --------
-                >>> from pyedb.dotnet.application.Variables import Variable
+        Examples
+        --------
+        >>> from pyedb.dotnet.application.Variables import Variable
 
-                Multiply ``'Length1'`` by unitless ``'None'``` to obtain ``'Length'``.
-                A numerical value is also considered to be unitless.
+        Multiply ``'Length1'`` by unitless ``'None'``` to obtain ``'Length'``.
+        A numerical value is also considered to be unitless.
 
-                >>> import ansys.aedt.core.generic.constants
-                >>> v1 = Variable("10mm")
-                >>> v2 = Variable(3)
-                >>> result_1 = v1 * v2
-                >>> result_2 = v1 * 3
-                >>> assert result_1.numeric_value == 30.0
-                >>> assert result_1.unit_system == "Length"
-                >>> assert result_2.numeric_value == result_1.numeric_value
-                >>> assert result_2.unit_system == "Length"
+        >>> import ansys.aedt.core.generic.constants
+        >>> v1 = Variable("10mm")
+        >>> v2 = Variable(3)
+        >>> result_1 = v1 * v2
+        >>> result_2 = v1 * 3
+        >>> assert result_1.numeric_value == 30.0
+        >>> assert result_1.unit_system == "Length"
+        >>> assert result_2.numeric_value == result_1.numeric_value
+        >>> assert result_2.unit_system == "Length"
 
-                Multiply voltage times current to obtain power.
+        Multiply voltage times current to obtain power.
 
-                >>> import ansys.aedt.core.generic.constants
-                >>> v3 = Variable("3mA")
-                >>> v4 = Variable("40V")
-                >>> result_3 = v3 * v4
-                >>> assert result_3.numeric_value == 0.12
-                >>> assert result_3.units == "W"
-                >>> assert result_3.unit_system == "Power"
+        >>> import ansys.aedt.core.generic.constants
+        >>> v3 = Variable("3mA")
+        >>> v4 = Variable("40V")
+        >>> result_3 = v3 * v4
+        >>> assert result_3.numeric_value == 0.12
+        >>> assert result_3.units == "W"
+        >>> assert result_3.unit_system == "Power"
 
         """
         assert is_number(other) or isinstance(other, Variable), "Multiplier must be a scalar quantity or a variable."

--- a/src/pyedb/dotnet/edb_core/edb_data/primitives_data.py
+++ b/src/pyedb/dotnet/edb_core/edb_data/primitives_data.py
@@ -158,7 +158,7 @@ class EdbPolygon(Primitive):
 
         Examples
         --------
-        >>> edbapp = pyaedt.Edb("myproject.aedb")
+        >>> edbapp = ansys.aedt.core.Edb("myproject.aedb")
         >>> top_layer_polygon = [poly for poly in edbapp.modeler.polygons if poly.layer_name == "Top Layer"]
         >>> for polygon in top_layer_polygon:
         >>>     polygon.move(vector=["2mm", "100um"])
@@ -191,7 +191,7 @@ class EdbPolygon(Primitive):
 
         Examples
         --------
-        >>> edbapp = pyaedt.Edb("myproject.aedb")
+        >>> edbapp = ansys.aedt.core.Edb("myproject.aedb")
         >>> top_layer_polygon = [poly for poly in edbapp.modeler.polygons if poly.layer_name == "Top Layer"]
         >>> for polygon in top_layer_polygon:
         >>>     polygon.rotate(angle=45)

--- a/src/pyedb/edb_logger.py
+++ b/src/pyedb/edb_logger.py
@@ -417,7 +417,7 @@ class EdbLogger(object):
 
 logger = logging.getLogger("Global")
 if any("aedt_logger" in str(i) for i in logger.filters):
-    from pyaedt.generic.settings import settings as pyaedt_settings
+    from ansys.aedt.core.generic.settings import settings as pyaedt_settings
 
     from pyedb.generic.settings import settings as pyaedb_settings
 


### PR DESCRIPTION
The one in settings was used in PyAEDT when PyEDB is initialized, so the warning was appearing in PyAEDT. 

I also changed the examples to avoid the warnings.