### PR TITLE
BUILD: Remove numpy>=2. compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "pywin32 >= 303;platform_system=='Windows'",
     "ansys-pythonnet >= 3.1.0rc3",
     "dotnetcore2 ==3.1.23;platform_system=='Linux'",
-    "numpy>=1.20.0,<2.2",
+    "numpy>=1.20.0,<2",
     "pandas>=1.1.0,<2.3",
     "pydantic>=2.6.4,<2.10",
     "Rtree >= 1.2.0",


### PR DESCRIPTION
This is a revert from a recent change. The reason for this is that we are having issues with `numpy>=2.` when working on Linux. Unfortunately, the last PR passed because no tests were performed on Linux os.

I'm not extactly sure of why things don't work as expected but here is my idea. When working with Linux, we leverage the libs from `"AnsysEM/v242/Linux64/common/mono/Linux64/lib64"` and also `dotnetcore` / `dotnetcore2` which comes with an embedded `dotnet`. However, this does not work well with `numpy>=2.`. This is probably due to missing symbols / conflicts associated to the libstdc++.so.6. Typically, GLIBCXX_3.4.26 is not found in AEDT's mono libstdc++ making this lib working with `dotnet<=6`.

To avoid breaking a lot of things for users, I propose that we do not allow `numpy>=2.` for the moment and wait for the `grpc` layer to be implemented. At that point, we will be able to remove the dotnet layer for linux and move forward as in `pyaedt`.