### PR TITLE
CI: Add pyaedt linux testing when releasing

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -137,8 +137,8 @@ jobs:
 # vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv    RUNNING ON SELF-HOSTED RUNNER    vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
 # =================================================================================================
 
-  test-pyaedt-main:
-    name: Testing PyAEDT main branch
+  test-pyaedt-main-windows:
+    name: Testing PyAEDT main branch (Windows)
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     needs: [smoke-tests]
     runs-on: [ self-hosted, Windows, pyaedt ]
@@ -146,9 +146,8 @@ jobs:
       - name: Install Git and checkout project
         uses: actions/checkout@v4
 
-      # Revert to previous verison due too setup-python#819
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
 
@@ -184,7 +183,7 @@ jobs:
           .venv\Scripts\Activate.ps1
           # Uninstall conflicting dependencies
           pip uninstall --yes vtk
-          pip install --extra-index-url https://wheels.vtk.org vtk-osmesa==9.2.20230527.dev0
+          pip install --extra-index-url https://wheels.vtk.org vtk-osmesa
 
       - name: Run PyAEDT tests
         uses: nick-fields/retry@v3
@@ -208,6 +207,81 @@ jobs:
           timeout_minutes: 40
           command: |
             .venv\Scripts\Activate.ps1
+            pytest --durations=50 -v external/pyaedt/_unittest_solvers
+
+# =================================================================================================
+# vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv    RUNNING ON SELF-HOSTED RUNNER    vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+# =================================================================================================
+
+  test-pyaedt-main-linux:
+    name: Testing PyAEDT main branch (Linux)
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    needs: [smoke-tests]
+    runs-on: [ self-hosted, Linux, pyaedt ]
+    steps:
+      - name: Install Git and checkout project
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+
+      - name: Create Python venv
+        run: |
+          python -m venv .venv
+
+      - name: Update pip
+        run: |
+          . .venv/bin/activate
+          python -m pip install -U pip
+
+      - name: Clone PyAEDT on main branch
+        uses: actions/checkout@v4
+        with:
+          repository: ansys/pyaedt
+          path: "external/pyaedt"
+          ref: "main"
+
+      - name: Install PyAEDT main branch version with its test dependencies
+        run: |
+          . .venv/bin/activate
+          pip install --no-cache-dir external/pyaedt[tests]
+
+      - name: Install PyEDB
+        run: |
+          . .venv/bin/activate
+          python -m pip install .
+
+      - name: Install CI dependencies (e.g. vtk-osmesa)
+        run: |
+          . .venv/bin/activate
+          # Uninstall conflicting dependencies
+          pip uninstall --yes vtk
+          pip install --extra-index-url https://wheels.vtk.org vtk-osmesa
+
+      - name: Run PyAEDT tests
+        uses: nick-fields/retry@v3
+        env:
+          PYTHONMALLOC: malloc
+        with:
+          max_attempts: 3
+          retry_on: error
+          timeout_minutes: 40
+          command: |
+            . .venv/bin/activate
+            pytest -n auto --dist loadfile --durations=50 -v external/pyaedt/_unittest
+
+      - name: Run PyAEDT solvers tests
+        uses: nick-fields/retry@v3
+        env:
+          PYTHONMALLOC: malloc
+        with:
+          max_attempts: 3
+          retry_on: error
+          timeout_minutes: 40
+          command: |
+            . .venv/bin/activate
             pytest --durations=50 -v external/pyaedt/_unittest_solvers
 
 # =================================================================================================
@@ -316,7 +390,7 @@ jobs:
   release:
     name: Release project
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
-    needs: [package]
+    needs: [package, test-pyaedt-main-windows]
     runs-on: ubuntu-latest
     # Specifying a GitHub environment is optional, but strongly encouraged
     environment: release

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -390,7 +390,7 @@ jobs:
   release:
     name: Release project
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
-    needs: [package, test-pyaedt-main-windows]
+    needs: [package, test-pyaedt-main-windows, test-pyaedt-main-linux]
     runs-on: ubuntu-latest
     # Specifying a GitHub environment is optional, but strongly encouraged
     environment: release


### PR DESCRIPTION
To avoid as much as possible a situation where pyaedt's CICD is no longer working after a release of pyedb, see #800, I'd like to add a job to tests pyaedt in Linux.

