### PR TITLE
CI: Add labeler for grpc transition

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -17,3 +17,7 @@ ci/cd:
 testing:
 - changed-files:
   - any-glob-to-any-file: ['tests/**/*',]
+
+grpc-transition:
+- changed-files:
+  - any-glob-to-any-file: ['src/pyedb/dotnet/edb_core/*',]

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -33,3 +33,7 @@
 - name: ci/cd
   description: ""
   color: b5f226
+
+- name: grpc-transition
+  description: Changes that need to be included in gRPC transition
+  color: A79962

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,37 @@
+name: Labeler
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+    paths:
+      - '../labels.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  label-syncer:
+    name: Syncer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: micnncim/action-label-syncer@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  labeler:
+    name: Set labels
+    needs: [label-syncer]
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+
+    # Label based on modified files
+    - name: Label based on changed files
+      uses: actions/labeler@v5
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Adds a label associated to the grpc transition. This will help to track changes that need to be added to the grpc changes.