### PR TITLE
FIX: IC Die Properties setter fixes

### DIFF
--- a/src/pyedb/configuration/cfg_components.py
+++ b/src/pyedb/configuration/cfg_components.py
@@ -65,7 +65,7 @@ class CfgComponents:
             if comp.port_properties:
                 c_db.port_properties = comp.port_properties
             if comp.ic_die_properties:
-                c_db.set_ic_die_properties = comp.ic_die_properties
+                c_db.ic_die_properties = comp.ic_die_properties
             if comp.pin_pair_model:
                 c_db.model_properties = {"pin_pair_model": comp.pin_pair_model}
             if comp.spice_model:

--- a/src/pyedb/dotnet/edb_core/cell/hierarchy/component.py
+++ b/src/pyedb/dotnet/edb_core/cell/hierarchy/component.py
@@ -1109,7 +1109,7 @@ class EDBComponent(Group):
             die_type = pascal_to_snake(ic_die_prop.GetType().ToString())
             temp["type"] = die_type
             if not die_type == "no_die":
-                temp["orientation"] = pascal_to_snake(ic_die_prop.GetOrientation())
+                temp["orientation"] = pascal_to_snake(ic_die_prop.GetOrientation().ToString())
                 if die_type == "wire_bond":
                     temp["height"] = ic_die_prop.GetHeightValue().ToString()
             return temp
@@ -1123,10 +1123,13 @@ class EDBComponent(Group):
         else:
             ic_die_prop = cp.GetDieProperty().Clone()
             die_type = kwargs.get("type")
+            ic_die_prop.SetType(getattr(self._edb.definition.DieType, snake_to_pascal(die_type)))
             if not die_type == "no_die":
                 orientation = kwargs.get("orientation")
                 if orientation:
-                    ic_die_prop.SetOrientation(getattr(self._edb.definition.DieType, snake_to_pascal(die_type)))
+                    ic_die_prop.SetOrientation(
+                        getattr(self._edb.definition.DieOrientation, snake_to_pascal(orientation))
+                    )
                 if die_type == "wire_bond":
                     height = kwargs.get("height")
                     if height:

--- a/tests/legacy/system/test_edb_components.py
+++ b/tests/legacy/system/test_edb_components.py
@@ -29,6 +29,7 @@ import pytest
 
 # from pyedb import Edb
 from pyedb.dotnet.edb import Edb
+from pyedb.dotnet.edb_core.cell.hierarchy.component import EDBComponent
 from tests.conftest import desktop_version, local_path
 from tests.legacy.system.conftest import test_subfolder
 
@@ -625,3 +626,14 @@ class TestClass:
         }
         edbapp.components["C378"].model_properties = pp
         assert edbapp.components["C378"].model_properties == pp
+
+    def test_ic_die_properties(self):
+        component: EDBComponent = self.edbapp.components["U8"]
+        assert component.ic_die_properties["type"] == "no_die"
+        assert "orientation" not in component.ic_die_properties
+        assert "height" not in component.ic_die_properties
+        component.ic_die_properties = {"type": "flip_chip"}
+        assert component.ic_die_properties["type"] == "flip_chip"
+        component.ic_die_properties = {"orientation": "chip_down"}
+        assert component.ic_die_properties["type"] == "flip_chip"
+        assert component.ic_die_properties["orientation"] == "chip_down"

--- a/tests/legacy/system/test_edb_components.py
+++ b/tests/legacy/system/test_edb_components.py
@@ -629,11 +629,17 @@ class TestClass:
 
     def test_ic_die_properties(self):
         component: EDBComponent = self.edbapp.components["U8"]
-        assert component.ic_die_properties["type"] == "no_die"
-        assert "orientation" not in component.ic_die_properties
-        assert "height" not in component.ic_die_properties
-        component.ic_die_properties = {"type": "flip_chip"}
-        assert component.ic_die_properties["type"] == "flip_chip"
-        component.ic_die_properties = {"orientation": "chip_down"}
-        assert component.ic_die_properties["type"] == "flip_chip"
-        assert component.ic_die_properties["orientation"] == "chip_down"
+        _assert_initial_ic_die_properties(component)
+        component.ic_die_properties = {"type": "flip_chip", "orientation": "chip_down"}
+        _assert_final_ic_die_properties(component)
+
+
+def _assert_initial_ic_die_properties(component: EDBComponent):
+    assert component.ic_die_properties["type"] == "no_die"
+    assert "orientation" not in component.ic_die_properties
+    assert "height" not in component.ic_die_properties
+
+
+def _assert_final_ic_die_properties(component: EDBComponent):
+    assert component.ic_die_properties["type"] == "flip_chip"
+    assert component.ic_die_properties["orientation"] == "chip_down"

--- a/tests/legacy/system/test_edb_configuration_2p0.py
+++ b/tests/legacy/system/test_edb_configuration_2p0.py
@@ -1037,5 +1037,5 @@ class TestClass:
         db: EdbType = edb_examples.get_si_verse()
         component = db.components["U8"]
         _assert_initial_ic_die_properties(component)
-        db.configuration.load(U8_IC_DIE_PROPERTIES)
+        db.configuration.load(U8_IC_DIE_PROPERTIES, apply_file=True)
         _assert_final_ic_die_properties(component)

--- a/tests/legacy/system/test_edb_configuration_2p0.py
+++ b/tests/legacy/system/test_edb_configuration_2p0.py
@@ -24,7 +24,25 @@ from pathlib import Path
 
 import pytest
 
+from pyedb.dotnet.edb import Edb as EdbType
+from tests.legacy.system.test_edb_components import (
+    _assert_final_ic_die_properties,
+    _assert_initial_ic_die_properties,
+)
+
 pytestmark = [pytest.mark.unit, pytest.mark.legacy]
+
+
+U8_IC_DIE_PROPERTIES = {
+    "components": [
+        {
+            "reference_designator": "U8",
+            "definition": "MAXM-T833+2_V",
+            "type": "ic",
+            "ic_die_properties": {"type": "flip_chip", "orientation": "chip_down"},
+        }
+    ]
+}
 
 
 class TestClass:
@@ -1014,3 +1032,10 @@ class TestClass:
         edbapp = edb_examples.get_si_verse()
         edbapp.configuration.load(data_from_db, apply_file=True)
         edbapp.close()
+
+    def test_17_ic_die_properties(self, edb_examples):
+        db: EdbType = edb_examples.get_si_verse()
+        component = db.components["U8"]
+        _assert_initial_ic_die_properties(component)
+        db.configuration.load(U8_IC_DIE_PROPERTIES)
+        _assert_final_ic_die_properties(component)


### PR DESCRIPTION
Fix `EDBComponent.ic_die_properties` setter and application of same from EDB configuration files.

Fixes #828 