### PR TITLE
CHORE: Temporary removal of docformatter hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,12 +44,12 @@ repos:
     args: ["--toml", "pyproject.toml"]
     additional_dependencies: [tomli]
 
-- repo: https://github.com/PyCQA/docformatter
-  rev: v1.7.5
-  hooks:
-  - id: docformatter
-    stages: [manual]
-    args: ["--config", "pyproject.toml"]
+# - repo: https://github.com/PyCQA/docformatter
+#   rev: v1.7.5
+#   hooks:
+#   - id: docformatter
+#     stages: [manual]
+#     args: ["--config", "pyproject.toml"]
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.5.0

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -246,7 +246,7 @@ else:
     config = {"run_examples": True}
 
 
-# Specify environment variable to build the doc without grpahical mode while
+# Specify environment variable to build the doc without graphical mode while
 # keeping examples graphical mode activated.
 os.environ["PYAEDT_NON_GRAPHICAL"] = "1"
 os.environ["PYAEDT_DOC_GENERATION"] = "1"

--- a/examples/use_configuration/set_up_edb_for_signal_integrity_analysis.py
+++ b/examples/use_configuration/set_up_edb_for_signal_integrity_analysis.py
@@ -174,5 +174,5 @@ solutions.plot()
 
 h3d.close_desktop()
 
-# All project files are saved in the folder ``temp_file.dir``. If you've run this example as a Jupyter notbook you
+# All project files are saved in the folder ``temp_file.dir``. If you've run this example as a Jupyter notebook you
 # can retrieve those project files.


### PR DESCRIPTION
As title says.

The reason for this change is related to a new major release of precommit where `python_venv` configuration can no longer be used. Since the docformatter is still using it ATM, we should temporarily comment this check.
Note that https://github.com/PyCQA/docformatter/pull/287 fixes the problem and has been merged last week. We are just waiting for a new release.