### PR TITLE
FIX: edb cfg cutout

### DIFF
--- a/src/pyedb/configuration/cfg_operations.py
+++ b/src/pyedb/configuration/cfg_operations.py
@@ -60,10 +60,11 @@ class CfgCutout(CfgBase):
 
                 net_names = []
                 for name, obj in self._pedb.nets.nets.items():
-                    if obj.primitives[0].layer.name == "pyedb_cutout":
-                        continue
-                    if len(obj.primitives) > 0:
-                        net_names.append(name)
+                    if obj.primitives:
+                        if obj.primitives[0].layer.name == "pyedb_cutout":
+                            continue
+                        else:
+                            net_names.append(name)
 
                 self.reference_list = []
                 self.signal_list = net_names


### PR DESCRIPTION
Some nets has no primitive. It leads to error.