### PR TITLE
FIX: polygon doesn't update after expansion

### DIFF
--- a/src/pyedb/configuration/cfg_padstacks.py
+++ b/src/pyedb/configuration/cfg_padstacks.py
@@ -62,7 +62,9 @@ class CfgPadstacks:
 
     def retrieve_parameters_from_edb(self):
         self.clean()
-        for _, obj in self._pedb.padstacks.definitions.items():
+        for name, obj in self._pedb.padstacks.definitions.items():
+            if name.lower() == "symbol":
+                continue
             pdef = CfgPadstackDefinition(self._pedb, obj)
             pdef.retrieve_parameters_from_edb()
             self.definitions.append(pdef)

--- a/src/pyedb/configuration/configuration.py
+++ b/src/pyedb/configuration/configuration.py
@@ -327,7 +327,7 @@ class Configuration:
         self,
         file_path,
         stackup=True,
-        package_definitions=True,
+        package_definitions=False,
         setups=True,
         sources=True,
         ports=True,

--- a/src/pyedb/dotnet/edb_core/cell/primitive/primitive.py
+++ b/src/pyedb/dotnet/edb_core/cell/primitive/primitive.py
@@ -753,27 +753,6 @@ class Primitive(Connectable):
             points.append(point)
         return points
 
-    def expand(self, offset=0.001, tolerance=1e-12, round_corners=True, maximum_corner_extension=0.001):
-        """Expand the polygon shape by an absolute value in all direction.
-        Offset can be negative for negative expansion.
-
-        Parameters
-        ----------
-        offset : float, optional
-            Offset value in meters.
-        tolerance : float, optional
-            Tolerance in meters.
-        round_corners : bool, optional
-            Whether to round corners or not.
-            If True, use rounded corners in the expansion otherwise use straight edges (can be degenerate).
-        maximum_corner_extension : float, optional
-            The maximum corner extension (when round corners are not used) at which point the corner is clipped.
-        """
-        pd = self.polygon_data
-        pd.expand(offset, tolerance, round_corners, maximum_corner_extension)
-        self.polygon_data = pd
-        return pd
-
     def scale(self, factor, center=None):
         """Scales the polygon relative to a center point by a factor.
 

--- a/src/pyedb/dotnet/edb_core/cell/primitive/primitive.py
+++ b/src/pyedb/dotnet/edb_core/cell/primitive/primitive.py
@@ -773,7 +773,9 @@ class Primitive(Connectable):
         maximum_corner_extension : float, optional
             The maximum corner extension (when round corners are not used) at which point the corner is clipped.
         """
-        return self.polygon_data.expand(offset, tolerance, round_corners, maximum_corner_extension)
+        pd = self.polygon_data
+        pd.expand(offset, tolerance, round_corners, maximum_corner_extension)
+        self.polygon_data = pd
 
     def scale(self, factor, center=None):
         """Scales the polygon relative to a center point by a factor.

--- a/src/pyedb/dotnet/edb_core/cell/primitive/primitive.py
+++ b/src/pyedb/dotnet/edb_core/cell/primitive/primitive.py
@@ -603,10 +603,6 @@ class Primitive(Connectable):
         """:class:`pyedb.dotnet.edb_core.dotnet.database.PolygonDataDotNet`: Outer contour of the Polygon object."""
         return PolygonData(self._pedb, self._edb_object.GetPolygonData())
 
-    @polygon_data.setter
-    def polygon_data(self, poly):
-        self._edb_object.SetPolygonData(poly._edb_object)
-
     def add_void(self, point_list):
         """Add a void to current primitive.
 
@@ -776,6 +772,7 @@ class Primitive(Connectable):
         pd = self.polygon_data
         pd.expand(offset, tolerance, round_corners, maximum_corner_extension)
         self.polygon_data = pd
+        return pd
 
     def scale(self, factor, center=None):
         """Scales the polygon relative to a center point by a factor.

--- a/src/pyedb/dotnet/edb_core/edb_data/primitives_data.py
+++ b/src/pyedb/dotnet/edb_core/edb_data/primitives_data.py
@@ -29,6 +29,7 @@ from pyedb.dotnet.edb_core.dotnet.primitive import (
     RectangleDotNet,
     TextDotNet,
 )
+from pyedb.dotnet.edb_core.geometry.polygon_data import PolygonData
 from pyedb.modeler.geometry_operators import GeometryOperators
 
 
@@ -304,6 +305,36 @@ class EdbPolygon(Primitive):
     #     else:
     #         prim = point_list
     #     return self.add_void(prim)
+
+    @property
+    def polygon_data(self):
+        """:class:`pyedb.dotnet.edb_core.dotnet.database.PolygonDataDotNet`: Outer contour of the Polygon object."""
+        return PolygonData(self._pedb, self._edb_object.GetPolygonData())
+
+    @polygon_data.setter
+    def polygon_data(self, poly):
+        self._edb_object.SetPolygonData(poly._edb_object)
+
+    def expand(self, offset=0.001, tolerance=1e-12, round_corners=True, maximum_corner_extension=0.001):
+        """Expand the polygon shape by an absolute value in all direction.
+        Offset can be negative for negative expansion.
+
+        Parameters
+        ----------
+        offset : float, optional
+            Offset value in meters.
+        tolerance : float, optional
+            Tolerance in meters.
+        round_corners : bool, optional
+            Whether to round corners or not.
+            If True, use rounded corners in the expansion otherwise use straight edges (can be degenerate).
+        maximum_corner_extension : float, optional
+            The maximum corner extension (when round corners are not used) at which point the corner is clipped.
+        """
+        pd = self.polygon_data
+        pd.expand(offset, tolerance, round_corners, maximum_corner_extension)
+        self.polygon_data = pd
+        return pd
 
 
 class EdbText(Primitive, TextDotNet):

--- a/src/pyedb/dotnet/edb_core/padstack.py
+++ b/src/pyedb/dotnet/edb_core/padstack.py
@@ -189,6 +189,8 @@ class EdbPadstacks(object):
             return self._definitions
         self._definitions = {}
         for padstackdef in self._pedb.padstack_defs:
+            if padstackdef.GetName().lower() == "symbol":
+                continue
             PadStackData = padstackdef.GetData()
             if len(PadStackData.GetLayerNames()) >= 1:
                 self._definitions[padstackdef.GetName()] = EDBPadstack(padstackdef, self)

--- a/src/pyedb/dotnet/edb_core/padstack.py
+++ b/src/pyedb/dotnet/edb_core/padstack.py
@@ -189,8 +189,6 @@ class EdbPadstacks(object):
             return self._definitions
         self._definitions = {}
         for padstackdef in self._pedb.padstack_defs:
-            if padstackdef.GetName().lower() == "symbol":
-                continue
             PadStackData = padstackdef.GetData()
             if len(PadStackData.GetLayerNames()) >= 1:
                 self._definitions[padstackdef.GetName()] = EDBPadstack(padstackdef, self)

--- a/tests/legacy/system/test_edb_modeler.py
+++ b/tests/legacy/system/test_edb_modeler.py
@@ -85,9 +85,6 @@ class TestClass:
             assert k.expand(0.0005)
             # edb.modeler.parametrize_polygon(k, poly_5953, offset_name=f"offset_{i}", origin=centroid)
 
-        poly_167 = [i for i in self.edbapp.modeler.paths if i.id == 167][0]
-        assert poly_167.expand(0.0005)
-
     def test_modeler_paths(self, edb_examples):
         """Evaluate modeler paths"""
         edbapp = edb_examples.get_si_verse()


### PR DESCRIPTION
- expand method from .net api create a new polygon. It needs to be set to the primitive.
- only polygon can expand. Move expand method to EdbPolygon class
- Remove uittest for Path
- do not export padstack definition by default. 