### PR TITLE
DOCS: Correct typos in class names/paths

### DIFF
--- a/doc/source/api/CoreEdb.rst
+++ b/doc/source/api/CoreEdb.rst
@@ -43,7 +43,7 @@ to AEDB files.
    materials.Materials
    modeler.Modeler
    nets.EdbNets
-   padstack.EDBPadstacks
+   edb_data.padstacks_data.EDBPadstack
    siwave.EdbSiwave
    stackup.Stackup
 

--- a/doc/source/api/SimulationConfigurationV2.rst
+++ b/doc/source/api/SimulationConfigurationV2.rst
@@ -25,9 +25,6 @@ These classes are the containers of simulation configuration constructors V2.0 f
    :toctree: _autosummary
    :nosignatures:
 
-   CfgPortProperties
-   CfgSolderBallsProperties
-   CfgRlcModel
    CfgComponent
    CfgComponents
 
@@ -81,8 +78,6 @@ These classes are the containers of simulation configuration constructors V2.0 f
    :nosignatures:
 
    CfgPadstacks
-   Definition
-   Instance
 
 .. currentmodule:: pyedb.configuration.cfg_pin_groups
 
@@ -126,7 +121,7 @@ These classes are the containers of simulation configuration constructors V2.0 f
    CfgSweepData
    CfgSetup
    CfgSIwaveACSetup
-   CfgSiwaveDCSetup
+   CfgSIwaveDCSetup
    CfgHFSSSetup
    CfgDcIrSettings
    CfgMeshOperation

--- a/doc/source/api/edb_data/PrimitivesData.rst
+++ b/doc/source/api/edb_data/PrimitivesData.rst
@@ -15,8 +15,8 @@ These classes are the containers of data management for primitives and arcs.
    :nosignatures:
 
 
-   EDBPrimitives
    EDBArcs
+   EdbPolygon
 
 
 .. code:: python

--- a/doc/source/api/sim_setup_data/data/settings.rst
+++ b/doc/source/api/sim_setup_data/data/settings.rst
@@ -14,9 +14,9 @@ These classes are the containers of HFSS simulation setup settings.
    DefeatureSettings
    AdvancedMeshSettings
    ViaSettings
-   CurveApproximationSettings
+   CurveApproxSettings
    DcrSettings
    HfssPortSettings
-   HfssSolveSettings
+   HfssSolverSettings
 
 

--- a/doc/source/api/utilities/simulation_setup.rst
+++ b/doc/source/api/utilities/simulation_setup.rst
@@ -11,7 +11,7 @@ This class is the container of simulation setup.
 
 
    SimulationSetupType
-   AdaptivveType
+   AdaptiveType
    SimulationSetup
 
 


### PR DESCRIPTION
@hui-zhou-a While working on a fix to #889 I found typos in class references. This should patch those.