### PR TITLE
CI: Update pyaedt tests jobs

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -262,7 +262,7 @@ jobs:
           timeout_minutes: 40
           command: |
             .venv\Scripts\Activate.ps1
-            pytest -n auto --dist loadfile --durations=50 -v external/pyaedt/_unittest
+            pytest -n auto --dist loadfile --durations=50 -v external/pyaedt/tests/system/general/
 
       - name: Run PyAEDT solvers tests
         uses: nick-fields/retry@v3
@@ -274,7 +274,7 @@ jobs:
           timeout_minutes: 40
           command: |
             .venv\Scripts\Activate.ps1
-            pytest --durations=50 -v external/pyaedt/_unittest_solvers
+            pytest --durations=50 -v external/external/pyaedt/tests/system/solvers
 
 # =================================================================================================
 # vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv    RUNNING ON SELF-HOSTED RUNNER    vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv


### PR DESCRIPTION
The release workflows was failing due to the changes in architecture of pyaedt.
The previous folders `_unittest` and `_unittest_solvers` are no longer existing.