### PR TITLE
FIX: DOTNET_ROOT handling with pyaedt

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -206,6 +206,7 @@ jobs:
 
   test-pyaedt-main-windows:
     name: Testing PyAEDT main branch (Windows)
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     needs: [smoke-tests]
     runs-on: [ self-hosted, Windows, pyaedt ]
     steps:
@@ -281,6 +282,7 @@ jobs:
 
   test-pyaedt-main-linux:
     name: Testing PyAEDT main branch (Linux)
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     needs: [smoke-tests]
     runs-on: [ self-hosted, Linux, pyaedt ]
     env:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -282,7 +282,6 @@ jobs:
 
   test-pyaedt-main-linux:
     name: Testing PyAEDT main branch (Linux)
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     needs: [smoke-tests]
     runs-on: [ self-hosted, Linux, pyaedt ]
     env:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -206,7 +206,6 @@ jobs:
 
   test-pyaedt-main-windows:
     name: Testing PyAEDT main branch (Windows)
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     needs: [smoke-tests]
     runs-on: [ self-hosted, Windows, pyaedt ]
     steps:

--- a/src/pyedb/dotnet/clr_module.py
+++ b/src/pyedb/dotnet/clr_module.py
@@ -48,6 +48,7 @@ if is_linux:  # pragma: no cover
             runtime = get_coreclr()
             load(runtime)
             print(runtime)
+            print(runtime.dotnet_root)
             # os.environ["DOTNET_ROOT"] = runtime.dotnet_root
             is_clr = True
         # TODO: Fall backing to dotnetcore2 should be removed in a near future.

--- a/src/pyedb/dotnet/clr_module.py
+++ b/src/pyedb/dotnet/clr_module.py
@@ -4,8 +4,6 @@ import pkgutil
 import sys
 import warnings
 
-from clr_loader import find_runtimes
-
 import pyedb
 
 LINUX_WARNING = (
@@ -70,6 +68,8 @@ if is_linux:  # pragma: no cover
         if dotnet_root.parent.name == "dotnetcore2":
             runtime_config = pyedb_path / "misc" / "pyedb.runtimeconfig.json"
         else:
+            from clr_loader import find_runtimes
+
             candidates = [rt for rt in find_runtimes() if rt.name == "Microsoft.NETCore.App"]
             candidates.sort(key=lambda spec: spec.version, reverse=True)
             if not candidates:

--- a/src/pyedb/dotnet/clr_module.py
+++ b/src/pyedb/dotnet/clr_module.py
@@ -47,9 +47,7 @@ if is_linux:  # pragma: no cover
 
             runtime = get_coreclr()
             load(runtime)
-            print(runtime)
-            print(runtime.dotnet_root)
-            # os.environ["DOTNET_ROOT"] = runtime.dotnet_root
+            os.environ["DOTNET_ROOT"] = str(runtime.dotnet_root)
             is_clr = True
         # TODO: Fall backing to dotnetcore2 should be removed in a near future.
         except Exception:

--- a/src/pyedb/dotnet/clr_module.py
+++ b/src/pyedb/dotnet/clr_module.py
@@ -1,7 +1,6 @@
 import os
 from pathlib import Path
 import pkgutil
-import shutil
 import sys
 import warnings
 
@@ -34,17 +33,6 @@ pyedb_path = Path(pyedb.__file__).parent
 sys.path.append(str(pyedb_path / "dlls" / "PDFReport"))
 
 
-def find_dotnet_root() -> Path:
-    """Find dotnet root path."""
-    dotnet_path = shutil.which("dotnet")
-    if not dotnet_path:
-        raise FileNotFoundError("The 'dotnet' executable was not found in the PATH.")
-
-    dotnet_path = Path(dotnet_path).resolve()
-    dotnet_root = dotnet_path.parent
-    return dotnet_root
-
-
 def find_runtime_config(dotnet_root: Path) -> Path:
     """Find dotnet runtime configuration file path."""
     sdk_path = dotnet_root / "sdk"
@@ -60,34 +48,37 @@ def find_runtime_config(dotnet_root: Path) -> Path:
 
 
 if is_linux:  # pragma: no cover
-    from pythonnet import load
+    dotnet_root = None
+    runtime_config = None
+    # Use system .NET core runtime or fall back to dotnetcore2
+    if os.environ.get("DOTNET_ROOT") is None:
+        try:
+            from clr_loader import get_coreclr
 
-    # Use system DOTNET core runtime
-    try:
-        from clr_loader import get_coreclr
+            runtime = get_coreclr()
+            load(runtime)
+            is_clr = True
+        # TODO: Fall backing to dotnetcore2 should be removed in a near future.
+        except Exception:
+            warnings.warn(
+                "Unable to set .NET root and locate the runtime configuration file. "
+                "Falling back to using dotnetcore2."
+            )
+            warnings.warn(LINUX_WARNING)
 
-        runtime = get_coreclr()
-        load(runtime)
-        is_clr = True
-    # Define DOTNET root and runtime config file to load DOTNET core runtime
-    except Exception:
-        if os.environ.get("DOTNET_ROOT") is None:
-            try:
-                dotnet_root = find_dotnet_root()
-                runtime_config = find_runtime_config(dotnet_root)
-            except Exception:
-                warnings.warn(
-                    "Unable to set DOTNET root and locate the runtime configuration file. "
-                    "Falling back to using dotnetcore2."
-                )
-                warnings.warn(LINUX_WARNING)
+            import dotnetcore2
 
-                import dotnetcore2
-
-                dotnet_root = Path(dotnetcore2.__file__).parent / "bin"
-                runtime_config = pyedb_path / "misc" / "pyedb.runtimeconfig.json"
+            dotnet_root = Path(dotnetcore2.__file__).parent / "bin"
+            runtime_config = pyedb_path / "misc" / "pyedb.runtimeconfig.json"
+    # Use specified .NET root folder
+    else:
+        dotnet_root = Path(os.environ["DOTNET_ROOT"])
+        # Patch the case where DOTNET_ROOT leads to dotnetcore2 for more information
+        # see https://github.com/ansys/pyedb/issues/922
+        # TODO: Remove once dotnetcore2 is deprecated
+        if dotnet_root.parent.name == "dotnetcore2":
+            runtime_config = pyedb_path / "misc" / "pyedb.runtimeconfig.json"
         else:
-            dotnet_root = Path(os.environ["DOTNET_ROOT"])
             try:
                 runtime_config = find_runtime_config(dotnet_root)
             except Exception as e:
@@ -96,6 +87,8 @@ if is_linux:  # pragma: no cover
                     "Please ensure that .NET SDK is correctly installed or "
                     "that DOTNET_ROOT is correctly set."
                 )
+    # Use specific .NET core runtime
+    if dotnet_root is not None and runtime_config is not None:
         try:
             load("coreclr", runtime_config=str(runtime_config), dotnet_root=str(dotnet_root))
             if "mono" not in os.getenv("LD_LIBRARY_PATH", ""):
@@ -103,10 +96,6 @@ if is_linux:  # pragma: no cover
                 warnings.warn("export ANSYSEM_ROOT242=/path/to/AnsysEM/v242/Linux64")
                 msg = "export LD_LIBRARY_PATH="
                 msg += "$ANSYSEM_ROOT242/common/mono/Linux64/lib64:$LD_LIBRARY_PATH"
-                msg += (
-                    "If PyEDB is used with AEDT<2023.2 then /path/to/AnsysEM/v2XY/Linux64/Delcross "
-                    "should be added to LD_LIBRARY_PATH."
-                )
                 warnings.warn(msg)
             is_clr = True
         except ImportError:

--- a/src/pyedb/dotnet/clr_module.py
+++ b/src/pyedb/dotnet/clr_module.py
@@ -83,6 +83,7 @@ if is_linux:  # pragma: no cover
     if dotnet_root is not None and runtime_config is not None:
         try:
             load("coreclr", runtime_config=str(runtime_config), dotnet_root=str(dotnet_root))
+            os.environ["DOTNET_ROOT"] = dotnet_root
             if "mono" not in os.getenv("LD_LIBRARY_PATH", ""):
                 warnings.warn("LD_LIBRARY_PATH needs to be setup to use pyedb.")
                 warnings.warn("export ANSYSEM_ROOT242=/path/to/AnsysEM/v242/Linux64")

--- a/src/pyedb/dotnet/clr_module.py
+++ b/src/pyedb/dotnet/clr_module.py
@@ -48,6 +48,8 @@ def find_runtime_config(dotnet_root: Path) -> Path:
 
 
 if is_linux:  # pragma: no cover
+    from pythonnet import load
+
     dotnet_root = None
     runtime_config = None
     # Use system .NET core runtime or fall back to dotnetcore2

--- a/src/pyedb/dotnet/clr_module.py
+++ b/src/pyedb/dotnet/clr_module.py
@@ -35,20 +35,6 @@ pyedb_path = Path(pyedb.__file__).parent
 sys.path.append(str(pyedb_path / "dlls" / "PDFReport"))
 
 
-def find_runtime_config(dotnet_root: Path) -> Path:
-    """Find dotnet runtime configuration file path."""
-    sdk_path = dotnet_root / "sdk"
-    if not sdk_path.is_dir():
-        raise EnvironmentError(f"The 'sdk' directory could not be found in: {dotnet_root}")
-    sdk_versions = sorted(sdk_path.iterdir(), key=lambda x: x.name, reverse=True)
-    if not sdk_versions:
-        raise FileNotFoundError("No SDK versions were found.")
-    runtime_config = sdk_versions[0] / "dotnet.runtimeconfig.json"
-    if not runtime_config.is_file():
-        raise FileNotFoundError(f"The configuration file '{runtime_config}' does not exist.")
-    return runtime_config
-
-
 if is_linux:  # pragma: no cover
     from pythonnet import load
 

--- a/src/pyedb/dotnet/clr_module.py
+++ b/src/pyedb/dotnet/clr_module.py
@@ -47,6 +47,7 @@ if is_linux:  # pragma: no cover
 
             runtime = get_coreclr()
             load(runtime)
+            os.environ["DOTNET_ROOT"] = runtime.dotnet_root
             is_clr = True
         # TODO: Fall backing to dotnetcore2 should be removed in a near future.
         except Exception:

--- a/src/pyedb/dotnet/clr_module.py
+++ b/src/pyedb/dotnet/clr_module.py
@@ -4,6 +4,8 @@ import pkgutil
 import sys
 import warnings
 
+from clr_loader import find_runtimes
+
 import pyedb
 
 LINUX_WARNING = (
@@ -81,14 +83,15 @@ if is_linux:  # pragma: no cover
         if dotnet_root.parent.name == "dotnetcore2":
             runtime_config = pyedb_path / "misc" / "pyedb.runtimeconfig.json"
         else:
-            try:
-                runtime_config = find_runtime_config(dotnet_root)
-            except Exception as e:
+            candidates = [rt for rt in find_runtimes() if rt.name == "Microsoft.NETCore.App"]
+            candidates.sort(key=lambda spec: spec.version, reverse=True)
+            if not candidates:
                 raise RuntimeError(
                     "Configuration file could not be found from DOTNET_ROOT. "
                     "Please ensure that .NET SDK is correctly installed or "
                     "that DOTNET_ROOT is correctly set."
                 )
+            runtime_config = candidates[0]
     # Use specific .NET core runtime
     if dotnet_root is not None and runtime_config is not None:
         try:

--- a/src/pyedb/dotnet/clr_module.py
+++ b/src/pyedb/dotnet/clr_module.py
@@ -47,7 +47,8 @@ if is_linux:  # pragma: no cover
 
             runtime = get_coreclr()
             load(runtime)
-            os.environ["DOTNET_ROOT"] = runtime.dotnet_root
+            print(runtime)
+            # os.environ["DOTNET_ROOT"] = runtime.dotnet_root
             is_clr = True
         # TODO: Fall backing to dotnetcore2 should be removed in a near future.
         except Exception:


### PR DESCRIPTION
As title says, see #922 for more information.

Below is the result after calling the same sequences that caused an error previously:

![image](https://github.com/user-attachments/assets/a03a67be-9633-4ab3-a743-2dac71a80016)

Close #922