### PR TITLE
FIX: Point terminal layer getter function

### DIFF
--- a/src/pyedb/dotnet/edb_core/cell/terminal/terminal.py
+++ b/src/pyedb/dotnet/edb_core/cell/terminal/terminal.py
@@ -105,12 +105,11 @@ class Terminal(Connectable):
     @property
     def layer(self):
         """Get layer of the terminal."""
-        point_data = self._pedb.point_data(0, 0)
-        layer = list(self._pedb.stackup.layers.values())[0]._edb_layer
-        if self._edb_object.GetParameters(point_data, layer):
+        try:
+            _, _, layer = self._edb_object.GetParameters()
             return self._pedb.stackup.all_layers[layer.GetName()]
-        else:
-            self._pedb.logger.warning(f"No pad parameters found for terminal {self.name}")
+        except:
+            self._pedb.logger.error("Cannot determine terminal layer")
 
     @layer.setter
     def layer(self, value):
@@ -121,9 +120,11 @@ class Terminal(Connectable):
     @property
     def location(self):
         """Location of the terminal."""
-        layer = list(self._pedb.stackup.layers.values())[0]._edb_layer
-        _, point_data, _ = self._edb_object.GetParameters(None, layer)
-        return [point_data.X.ToDouble(), point_data.Y.ToDouble()]
+        try:
+            _, point_data, _ = self._edb_object.GetParameters()
+            return [point_data.X.ToDouble(), point_data.Y.ToDouble()]
+        except:
+            self._pedb.logger.error("Cannot determine terminal location")
 
     @location.setter
     def location(self, value):


### PR DESCRIPTION
Duplicates PR #945 which was created from a fork.

The layer getter property of the point terminal always returned the top layer name irrespective of where the terminal was located. This has been fixed.

(cherry picked from commit 265b4b3db7487e050270a9e9a81a88538cd1501f)