### PR TITLE
CI: Validate apt install of tk

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -296,7 +296,7 @@ jobs:
       - name: Install OS packages
         run: |
           sudo apt update
-          sudo apt-get install tk
+          sudo apt-get install tk -y
 
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
With the new VM creation, some miscellaneous behavior got detected.

This PR fixes current release failure by ensuring required apt packages are installed (see https://github.com/ansys/pyedb/actions/runs/12765093240/job/35585355359#step:3:40)