### PR TITLE
CI: Deselect from project root

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -366,7 +366,7 @@ jobs:
             export LD_LIBRARY_PATH=${{ env.ANSYSEM_ROOT242 }}/common/mono/Linux64/lib64:$LD_LIBRARY_PATH
             . .venv/bin/activate
             pytest --durations=50 -v external/pyaedt/tests/system/solvers/test_45_workflows.py
-            pytest --durations=50 -v external/pyaedt/tests/system/solvers --deselect=external/pyaedt/tests/system/solvers/test_45_workflows.py
+            pytest --durations=50 -v external/pyaedt/tests/system/solvers --deselect=tests/system/solvers/test_45_workflows.py
 
 # =================================================================================================
 # vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv    RUNNING ON SELF-HOSTED RUNNER    vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv


### PR DESCRIPTION
Previous deselection (https://github.com/ansys/pyedb/pull/989) was failing because it must be specified from project root.
I tried it locally and from a folder `src` where I cloned `pyedb`, when I run `pytest pyedb/tests/legacy/unit --deselect=tests/legacy/unit/test_edb.py -vvv` the edb tests are correctly unselected (11 unselected tests)

For more information on that deselection requirement see https://github.com/ansys/pyedb/pull/987 and https://github.com/ansys/pyedb/issues/988
Note that https://github.com/ansys/pyedb/commit/da26422756f2dcf972ab659a4777354e7bf76251 was able to pass the file test that was previously failing.