### PR TITLE
FIX: merge via filtered by start and stop layers

### DIFF
--- a/src/pyedb/dotnet/edb_core/padstack.py
+++ b/src/pyedb/dotnet/edb_core/padstack.py
@@ -1651,7 +1651,7 @@ class EdbPadstacks(object):
                 if net_filter:
                     # instances = [id for id in instances if not self.instances[id].net_name in net_filter]
                     instances = [id for id in instances if all_instances[id].net_name not in net_filter]
-
+                # filter instances by start and stop layer
                 if start_layer:
                     if start_layer not in self._pedb.stackup.layers.keys():
                         raise Exception(f"{start_layer} not exist")

--- a/src/pyedb/dotnet/edb_core/padstack.py
+++ b/src/pyedb/dotnet/edb_core/padstack.py
@@ -1711,7 +1711,7 @@ class EdbPadstacks(object):
                     merged_instance.stop_layer = stop_layer
 
                     merged_via_ids.append(merged_instance.id)
-                    [all_instances[id].delete() for id in instances]
+                    _ = [all_instances[id].delete() for id in instances]
         return merged_via_ids
 
     def merge_via_along_lines(

--- a/src/pyedb/dotnet/edb_core/padstack.py
+++ b/src/pyedb/dotnet/edb_core/padstack.py
@@ -1651,7 +1651,9 @@ class EdbPadstacks(object):
                 raise Exception(f"No padstack instances found inside {contour_box}")
             else:
                 if net_filter:
-                    instances = [id for id in instances if not self.instances[id].net_name in net_filter]
+                    # instances = [id for id in instances if not self.instances[id].net_name in net_filter]
+                    instances_dict = self.instances
+                    instances = [id for id in instances if instances_dict[id].net_name not in net_filter]
 
                 net = self.instances[instances[0]].net_name
                 x_values = []
@@ -1692,7 +1694,7 @@ class EdbPadstacks(object):
                     merged_instance.stop_layer = stop_layer
 
                     merged_via_ids.append(merged_instance.id)
-                    [self.instances[id].delete() for id in instances]
+                    [instances_dict[id].delete() for id in instances]
         return merged_via_ids
 
     def merge_via_along_lines(

--- a/src/pyedb/dotnet/edb_core/padstack.py
+++ b/src/pyedb/dotnet/edb_core/padstack.py
@@ -1641,7 +1641,7 @@ class EdbPadstacks(object):
         for id, inst in self.instances.items():
             instances_index[id] = inst.position
         for contour_box in contour_boxes:
-            all_instances_dict = self.instances
+            all_instances = self.instances
             instances = self.get_padstack_instances_id_intersecting_polygon(
                 points=contour_box, padstack_instances_index=instances_index
             )
@@ -1650,18 +1650,18 @@ class EdbPadstacks(object):
             else:
                 if net_filter:
                     # instances = [id for id in instances if not self.instances[id].net_name in net_filter]
-                    instances = [id for id in instances if all_instances_dict[id].net_name not in net_filter]
+                    instances = [id for id in instances if all_instances[id].net_name not in net_filter]
 
                 if start_layer:
                     if start_layer not in self._pedb.stackup.layers.keys():
                         raise Exception(f"{start_layer} not exist")
                     else:
-                        instances = [id for id in instances if all_instances_dict[id].start_layer == start_layer]
+                        instances = [id for id in instances if all_instances[id].start_layer == start_layer]
                 if stop_layer:
                     if stop_layer not in self._pedb.stackup.layers.keys():
                         raise Exception(f"{stop_layer} not exist")
                     else:
-                        instances = [id for id in instances if all_instances_dict[id].stop_layer == stop_layer]
+                        instances = [id for id in instances if all_instances[id].stop_layer == stop_layer]
                 if not instances:
                     raise Exception(
                         f"No padstack instances found inside {contour_box} between {start_layer} and {stop_layer}"
@@ -1711,7 +1711,7 @@ class EdbPadstacks(object):
                     merged_instance.stop_layer = stop_layer
 
                     merged_via_ids.append(merged_instance.id)
-                    [all_instances_dict[id].delete() for id in instances]
+                    [all_instances[id].delete() for id in instances]
         return merged_via_ids
 
     def merge_via_along_lines(

--- a/src/pyedb/dotnet/edb_core/padstack.py
+++ b/src/pyedb/dotnet/edb_core/padstack.py
@@ -1664,7 +1664,7 @@ class EdbPadstacks(object):
                         instances = [id for id in instances if all_instances_dict[id].stop_layer == stop_layer]
                 if not instances:
                     raise Exception(
-                        f"No padstack instances found inside {contour_box} between {start_layer} and" f"{stop_layer}"
+                        f"No padstack instances found inside {contour_box} between {start_layer} and {stop_layer}"
                     )
 
                 if not start_layer:

--- a/src/pyedb/dotnet/edb_core/padstack.py
+++ b/src/pyedb/dotnet/edb_core/padstack.py
@@ -1636,14 +1636,12 @@ class EdbPadstacks(object):
         merged_via_ids = []
         if not contour_boxes:
             raise Exception("No contour box provided, you need to pass a nested list as argument.")
-        if not start_layer:
-            start_layer = list(self._pedb.stackup.layers.values())[0].name
-        if not stop_layer:
-            stop_layer = list(self._pedb.stackup.layers.values())[-1].name
+
         instances_index = {}
         for id, inst in self.instances.items():
             instances_index[id] = inst.position
         for contour_box in contour_boxes:
+            all_instances_dict = self.instances
             instances = self.get_padstack_instances_id_intersecting_polygon(
                 points=contour_box, padstack_instances_index=instances_index
             )
@@ -1652,8 +1650,27 @@ class EdbPadstacks(object):
             else:
                 if net_filter:
                     # instances = [id for id in instances if not self.instances[id].net_name in net_filter]
-                    instances_dict = self.instances
-                    instances = [id for id in instances if instances_dict[id].net_name not in net_filter]
+                    instances = [id for id in instances if all_instances_dict[id].net_name not in net_filter]
+
+                if start_layer:
+                    if start_layer not in self._pedb.stackup.layers.keys():
+                        raise Exception(f"{start_layer} not exist")
+                    else:
+                        instances = [id for id in instances if all_instances_dict[id].start_layer == start_layer]
+                if stop_layer:
+                    if stop_layer not in self._pedb.stackup.layers.keys():
+                        raise Exception(f"{stop_layer} not exist")
+                    else:
+                        instances = [id for id in instances if all_instances_dict[id].stop_layer == stop_layer]
+                if not instances:
+                    raise Exception(
+                        f"No padstack instances found inside {contour_box} between {start_layer} and" f"{stop_layer}"
+                    )
+
+                if not start_layer:
+                    start_layer = list(self._pedb.stackup.layers.values())[0].name
+                if not stop_layer:
+                    stop_layer = list(self._pedb.stackup.layers.values())[-1].name
 
                 net = self.instances[instances[0]].net_name
                 x_values = []
@@ -1694,7 +1711,7 @@ class EdbPadstacks(object):
                     merged_instance.stop_layer = stop_layer
 
                     merged_via_ids.append(merged_instance.id)
-                    [instances_dict[id].delete() for id in instances]
+                    [all_instances_dict[id].delete() for id in instances]
         return merged_via_ids
 
     def merge_via_along_lines(


### PR DESCRIPTION
This pull request added padstack instances selection by start and stop layers in cases where vias belong to different layers but overlap in the same polygon.

Speed up the searching through self.instances.