### PR TITLE
FEAT: Edb cfg equipotential

### DIFF
--- a/examples/use_configuration/import_sources.py
+++ b/examples/use_configuration/import_sources.py
@@ -48,8 +48,8 @@ cfg = dict()
 # - **Reference_designator**. Reference designator of the component.
 # - **type**. Type of the source. Supported types are 'voltage', 'current'
 # - **positive_terminal**. Supported types are 'net', 'pin', 'pin_group', 'coordinates'
-# - **negative_terminal**. Supported types are 'net', 'pin', 'pin_group', 'coordinates',
-# 'nearest_pin'
+# - **negative_terminal**. Supported types are 'net', 'pin', 'pin_group', 'coordinates'
+# - **equipotential**. Set equipotential region on pins when True.
 
 voltage_source = {
     "name": "V_SOURCE_5V",
@@ -58,6 +58,7 @@ voltage_source = {
     "magnitude": 1,
     "positive_terminal": {"net": "5V"},
     "negative_terminal": {"net": "GND"},
+    "equipotential": True,
 }
 
 # ## Add a current source between two pins
@@ -92,12 +93,16 @@ current_source_2 = {
 # - **layer**. Layer on which the terminal is placed
 # - **point**. XY coordinate the terminal is placed
 # - **net**. Name of the net the terminal is placed on
+# - **contact_radius**. Set an equipotential region at the contact point.
 
 current_source_3 = {
     "name": "CURRENT_SOURCE_3",
     "type": "current",
-    "positive_terminal": {"coordinates": {"layer": "1_Top", "point": ["116mm", "41mm"], "net": "5V"}},
-    "negative_terminal": {"coordinates": {"layer": "Inner1(GND1)", "point": ["116mm", "41mm"], "net": "GND"}},
+    "equipotential": True,
+    "positive_terminal": {
+        "coordinates": {"layer": "1_Top", "point": ["116mm", "41mm"], "net": "5V", "contact_radius": "1mm"}},
+    "negative_terminal": {
+        "coordinates": {"layer": "Inner1(GND1)", "point": ["116mm", "41mm"], "net": "GND", "contact_radius": "1mm"}},
 }
 
 # ## Add a current source reference to the nearest pin

--- a/src/pyedb/configuration/cfg_ports_sources.py
+++ b/src/pyedb/configuration/cfg_ports_sources.py
@@ -46,6 +46,7 @@ class CfgCoordianteTerminalInfo(CfgTerminalInfo):
         self.point_x = self.value["point"][0]
         self.point_y = self.value["point"][1]
         self.net = self.value["net"]
+        self.contact_radius = self.value.get("contact_radius", None)
 
     def export_properties(self):
         return {"coordinates": {"layer": self.layer, "point": [self.point_x, self.point_y], "net": self.net}}
@@ -244,6 +245,9 @@ class CfgCircuitElement(CfgBase):
             point = [self.positive_terminal_info.point_x, self.positive_terminal_info.point_y]
             net_name = self.positive_terminal_info.net
             pos_coor_terminal[self.name] = self._pedb.get_point_terminal(self.name, net_name, point, layer)
+            if self.positive_terminal_info.contact_radius:
+                pos_coor_terminal[self.name].contact_radius = self.positive_terminal_info.contact_radius
+
         elif pos_type == "pin_group":
             if self.distributed:
                 pins = self._get_pins(pos_type, pos_value)
@@ -276,7 +280,7 @@ class CfgCircuitElement(CfgBase):
 
             if neg_type == "coordinates":
                 layer = self.negative_terminal_info.layer
-                point = [self.negative_terminal_info.point_x, self.positive_terminal_info.point_y]
+                point = [self.negative_terminal_info.point_x, self.negative_terminal_info.point_y]
                 net_name = self.negative_terminal_info.net
                 self.neg_terminal = self._pedb.get_point_terminal(self.name + "_ref", net_name, point, layer)
             elif neg_type == "nearest_pin":
@@ -378,6 +382,7 @@ class CfgSource(CfgCircuitElement):
         super().__init__(pedb, **kwargs)
 
         self.magnitude = kwargs.get("magnitude", 0.001)
+        self.equipotential = kwargs.get("equipotential", False)
 
     def set_parameters_to_edb(self):
         """Create sources."""
@@ -397,6 +402,33 @@ class CfgSource(CfgCircuitElement):
                 elem.name = f"{self.name}_{elem.name}"
                 elem.magnitude = self.magnitude / self._elem_num
             circuit_elements.append(elem)
+        for terminal in circuit_elements:
+
+            if self.equipotential:
+                terms = [terminal, terminal.ref_terminal] if terminal.ref_terminal else [terminal]
+                for t in terms:
+                    pads = []
+                    if t.terminal_type == "PadstackInstanceTerminal":
+                        pads.append(t.reference_object)
+                        t._edb_object.dcir_equipotential_region = True
+                    elif t.terminal_type == "PinGroupTerminal":
+                        name = t._edb_object.GetPinGroup().GetName()
+                        pg = self._pedb.siwave.pin_groups[name]
+                        pads.extend([i for _, i in pg.pins.items()])
+                    elif t.terminal_type == "PointTerminal":
+                        temp = [i for i in self._pedb.layout.terminals if i.name == t.name][0]
+                        if not temp.is_reference_terminal:
+                            radius = self.positive_terminal_info.contact_radius
+                        else:
+                            radius = self.negative_terminal_info.contact_radius
+                        if radius is not None:
+                            prim = self._pedb.modeler.create_circle(
+                                temp.layer.name, temp.location[0], temp.location[1], radius, temp.net_name)
+                            prim.dcir_equipotential_region = True
+
+                    for i in pads:
+                        i._set_equipotential()
+
         return circuit_elements
 
     def export_properties(self):

--- a/src/pyedb/dotnet/edb_core/cell/primitive/primitive.py
+++ b/src/pyedb/dotnet/edb_core/cell/primitive/primitive.py
@@ -19,6 +19,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import re
 
 from pyedb.dotnet.edb_core.cell.connectable import Connectable
 from pyedb.dotnet.edb_core.general import convert_py_list_to_net_list
@@ -814,7 +815,7 @@ class Primitive(Connectable):
         )
 
         pid = self._pedb.edb_api.ProductId.Designer
-        _, p = self._edb_padstackinstance.GetProductProperty(pid, 18, "")
+        _, p = self._edb_object.GetProductProperty(pid, 18, "")
         if p:
             return p
         else:
@@ -824,4 +825,29 @@ class Primitive(Connectable):
     def _em_properties(self, em_prop):
         """Set EM properties"""
         pid = self._pedb.edb_api.ProductId.Designer
-        self._edb_padstackinstance.SetProductProperty(pid, 18, em_prop)
+        self._edb_object.SetProductProperty(pid, 18, em_prop)
+
+    @property
+    def dcir_equipotential_region(self):
+        """Check whether dcir equipotential region is enabled.
+
+        Returns
+        -------
+        bool
+        """
+        pattern = r"'DCIR Equipotential Region'='([^']+)'"
+        em_pp = self._em_properties
+        result = re.search(pattern, em_pp).group(1)
+        if result == "true":
+            return True
+        else:
+            return False
+
+    @dcir_equipotential_region.setter
+    def dcir_equipotential_region(self, value):
+        """Set dcir equipotential region."""
+        pp = r"'DCIR Equipotential Region'='true'" if value else r"'DCIR Equipotential Region'='false'"
+        em_pp = self._em_properties
+        pattern = r"'DCIR Equipotential Region'='([^']+)'"
+        new_em_pp = re.sub(pattern, pp, em_pp)
+        self._em_properties = new_em_pp

--- a/src/pyedb/dotnet/edb_core/cell/primitive/primitive.py
+++ b/src/pyedb/dotnet/edb_core/cell/primitive/primitive.py
@@ -787,3 +787,41 @@ class Primitive(Connectable):
                 self.polygon_data = polygon_data
                 return True
         return False
+
+    @property
+    def _em_properties(self):
+        """Get EM properties."""
+        default = (
+            r"$begin 'EM properties'\n"
+            r"\tType('Mesh')\n"
+            r"\tDataId='EM properties1'\n"
+            r"\t$begin 'Properties'\n"
+            r"\t\tGeneral=''\n"
+            r"\t\tModeled='true'\n"
+            r"\t\tUnion='true'\n"
+            r"\t\t'Use Precedence'='false'\n"
+            r"\t\t'Precedence Value'='1'\n"
+            r"\t\tPlanarEM=''\n"
+            r"\t\tRefined='true'\n"
+            r"\t\tRefineFactor='1'\n"
+            r"\t\tNoEdgeMesh='false'\n"
+            r"\t\tHFSS=''\n"
+            r"\t\t'Solve Inside'='false'\n"
+            r"\t\tSIwave=''\n"
+            r"\t\t'DCIR Equipotential Region'='false'\n"
+            r"\t$end 'Properties'\n"
+            r"$end 'EM properties'\n"
+        )
+
+        pid = self._pedb.edb_api.ProductId.Designer
+        _, p = self._edb_padstackinstance.GetProductProperty(pid, 18, "")
+        if p:
+            return p
+        else:
+            return default
+
+    @_em_properties.setter
+    def _em_properties(self, em_prop):
+        """Set EM properties"""
+        pid = self._pedb.edb_api.ProductId.Designer
+        self._edb_padstackinstance.SetProductProperty(pid, 18, em_prop)

--- a/src/pyedb/dotnet/edb_core/edb_data/padstacks_data.py
+++ b/src/pyedb/dotnet/edb_core/edb_data/padstacks_data.py
@@ -1249,44 +1249,6 @@ class EDBPadstackInstance(Primitive):
         return self._pedb.create_port(terminal, ref_terminal, is_circuit_port)
 
     @property
-    def _em_properties(self):
-        """Get EM properties."""
-        default = (
-            r"$begin 'EM properties'\n"
-            r"\tType('Mesh')\n"
-            r"\tDataId='EM properties1'\n"
-            r"\t$begin 'Properties'\n"
-            r"\t\tGeneral=''\n"
-            r"\t\tModeled='true'\n"
-            r"\t\tUnion='true'\n"
-            r"\t\t'Use Precedence'='false'\n"
-            r"\t\t'Precedence Value'='1'\n"
-            r"\t\tPlanarEM=''\n"
-            r"\t\tRefined='true'\n"
-            r"\t\tRefineFactor='1'\n"
-            r"\t\tNoEdgeMesh='false'\n"
-            r"\t\tHFSS=''\n"
-            r"\t\t'Solve Inside'='false'\n"
-            r"\t\tSIwave=''\n"
-            r"\t\t'DCIR Equipotential Region'='false'\n"
-            r"\t$end 'Properties'\n"
-            r"$end 'EM properties'\n"
-        )
-
-        pid = self._pedb.edb_api.ProductId.Designer
-        _, p = self._edb_padstackinstance.GetProductProperty(pid, 18, "")
-        if p:
-            return p
-        else:
-            return default
-
-    @_em_properties.setter
-    def _em_properties(self, em_prop):
-        """Set EM properties"""
-        pid = self._pedb.edb_api.ProductId.Designer
-        self._edb_padstackinstance.SetProductProperty(pid, 18, em_prop)
-
-    @property
     def dcir_equipotential_region(self):
         """Check whether dcir equipotential region is enabled.
 
@@ -1577,7 +1539,6 @@ class EDBPadstackInstance(Primitive):
         str
             Name of the starting layer.
         """
-        layer = self._pedb.edb_api.cell.layer("", self._pedb.edb_api.cell.layer_type.SignalLayer)
         _, start_layer, stop_layer = self._edb_object.GetLayerRange()
 
         if start_layer:
@@ -1599,7 +1560,6 @@ class EDBPadstackInstance(Primitive):
         str
             Name of the stopping layer.
         """
-        layer = self._pedb.edb_api.cell.layer("", self._pedb.edb_api.cell.layer_type.SignalLayer)
         _, start_layer, stop_layer = self._edb_padstackinstance.GetLayerRange()
 
         if stop_layer:

--- a/src/pyedb/dotnet/edb_core/edb_data/padstacks_data.py
+++ b/src/pyedb/dotnet/edb_core/edb_data/padstacks_data.py
@@ -22,7 +22,6 @@
 
 from collections import OrderedDict
 import math
-import re
 import warnings
 
 from pyedb.dotnet.clr_module import String

--- a/tests/legacy/system/test_edb_configuration_2p0.py
+++ b/tests/legacy/system/test_edb_configuration_2p0.py
@@ -1026,6 +1026,37 @@ class TestClass:
         assert edbapp.configuration.load(data, apply_file=True)
         edbapp.close()
 
+    def test_15d_sources_equipotential(self, edb_examples):
+        edbapp = edb_examples.get_si_verse()
+        sources_i = [
+            {
+                "name": "ISOURCE_J5",
+                "reference_designator": "J5",
+                "type": "current",
+                "magnitude": 17,
+                "positive_terminal": {"net": "SFPA_VCCR"},
+                "negative_terminal": {"net": "GND"},
+                "equipotential": True,
+            },
+            {
+                "name": "x_y_port",
+                "type": "current",
+                "magnitude": 2,
+                "equipotential": True,
+                "positive_terminal": {
+                    "coordinates": {"layer": "1_Top", "point": ["104mm", "37mm"], "net": "AVCC_1V3",
+                                    "contact_radius": "1mm"}
+                },
+                "negative_terminal": {
+                    "coordinates": {"layer": "Inner6(GND2)", "point": ["104mm", "45mm"], "net": "GND",
+                                    "contact_radius": "1.2mm"}
+                },
+            }
+        ]
+        data = {"sources": sources_i}
+        assert edbapp.configuration.load(data, apply_file=True)
+        edbapp.close()
+
     def test_16_components_rlc(self, edb_examples):
         components = [
             {


### PR DESCRIPTION
- Move _em_proerties to Primitive class, since it is accessible for all primitives not only padstack.
- EDB API has a bug in equipotential region. The workaround is to create a primitive and make it equipotential region
- New feature in edb config. The user is able to define an equipotential region for sources with point terminals.
- Deleted some redundant lines