### PR TITLE
FIX: Primitive casting

### DIFF
--- a/src/pyedb/dotnet/edb_core/cell/layout.py
+++ b/src/pyedb/dotnet/edb_core/cell/layout.py
@@ -220,7 +220,7 @@ class Layout(ObjBase):
         -------
         """
 
-        return [EDBNetsData(net, self._pedb) for net in self._edb_object.Nets]
+        return [EDBNetsData(net, self._pedb) for net in self._edb_object.Nets if net]
 
     @property
     def primitives(self):
@@ -230,7 +230,7 @@ class Layout(ObjBase):
         -------
         list of :class:`dotnet.edb_core.dotnet.primitive.PrimitiveDotNet` cast objects.
         """
-        return [primitive_cast(self._pedb, p) for p in self._edb_object.Primitives]
+        return [primitive_cast(self._pedb, p) for p in self._edb_object.Primitives if p]
 
     @property
     def bondwires(self):

--- a/src/pyedb/dotnet/edb_core/edb_data/nets_data.py
+++ b/src/pyedb/dotnet/edb_core/edb_data/nets_data.py
@@ -59,7 +59,7 @@ class EDBNetsData(NetDotNet):
         """
         from pyedb.dotnet.edb_core.cell.layout import primitive_cast
 
-        return [primitive_cast(self._app, i) for i in self.net_object.Primitives]
+        return [primitive_cast(self._app, i) for i in self.net_object.Primitives if i]
         # return [self._app.layout.find_object_by_id(i.GetId()) for i in self.net_object.Primitives]
 
     @property


### PR DESCRIPTION
Sometimes Primitives contains empty objects (probably after boolean operations). This cause the casting to fail.