### PR TITLE
FIX: Circuit port creation on multiple pins

### DIFF
--- a/src/pyedb/dotnet/database/components.py
+++ b/src/pyedb/dotnet/database/components.py
@@ -820,12 +820,13 @@ class Components(object):
         if not port_name:
             port_name = "Port_{}_{}".format(pins[0].net_name, pins[0].name)
 
-        if len(pins) > 1 > 1 or pingroup_on_single_pin:
-            pec_boundary = False
-            self._logger.info(
-                "Disabling PEC boundary creation, this feature is supported on single pin "
-                f"ports only, {len(pins)} pins found (pingroup_on_single_pin: {pingroup_on_single_pin})."
-            )
+        if len(pins) > 1 or pingroup_on_single_pin:
+            if pec_boundary:
+                pec_boundary = False
+                self._logger.info(
+                    "Disabling PEC boundary creation, this feature is supported on single pin "
+                    f"ports only, {len(pins)} pins found (pingroup_on_single_pin: {pingroup_on_single_pin})."
+                )
             group_name = "group_{}".format(port_name)
             pin_group = self.create_pingroup_from_pins(pins, group_name)
             term = self._create_pin_group_terminal(pingroup=pin_group, term_name=port_name)
@@ -834,12 +835,13 @@ class Components(object):
         term.SetIsCircuitPort(True)
 
         if len(reference_pins) > 1 or pingroup_on_single_pin:
-            pec_boundary = False
-            self._logger.info(
-                "Disabling PEC boundary creation. This feature is supported on single pin "
-                f"ports only, {len(reference_pins)} reference pins found "
-                f"(pingroup_on_single_pin: {pingroup_on_single_pin})."
-            )
+            if pec_boundary:
+                pec_boundary = False
+                self._logger.info(
+                    "Disabling PEC boundary creation. This feature is supported on single pin "
+                    f"ports only, {len(reference_pins)} reference pins found "
+                    f"(pingroup_on_single_pin: {pingroup_on_single_pin})."
+                )
             ref_group_name = "group_{}_ref".format(port_name)
             ref_pin_group = self.create_pingroup_from_pins(reference_pins, ref_group_name)
             ref_term = self._create_pin_group_terminal(pingroup=ref_pin_group, term_name=port_name + "_ref")

--- a/tests/legacy/system/test_edb.py
+++ b/tests/legacy/system/test_edb.py
@@ -2002,6 +2002,21 @@ class TestClass:
         )
         assert len(edbapp.excitations) == 2
 
+    def test_create_circuit_port_on_component_pins_pingroup_on_multiple_pins(self, edb_examples):
+        edbapp = edb_examples.get_si_verse()
+        component_name = "U1"
+        edbcomp = edbapp.components[component_name]
+        positive_pin_names = ["R20", "R21", "T20"]
+        reference_pin_names = ["N21", "R19", "T21"]
+        assert edbapp.components.create_port_on_pins(
+            refdes=edbcomp,
+            pins=positive_pin_names,
+            reference_pins=reference_pin_names,
+        )
+        assert len(edbapp.excitations) == 2
+        for excitation in edbapp.excitations.values():
+            assert excitation.terminal_type == "PinGroupTerminal"
+
     def test_create_circuit_port_on_component_pins_pingroup_on_single_pin(self, edb_examples):
         edbapp = edb_examples.get_si_verse()
         component_name = "U10"

--- a/tests/legacy/system/test_edb.py
+++ b/tests/legacy/system/test_edb.py
@@ -2007,6 +2007,7 @@ class TestClass:
     def test_create_circuit_port_on_component_pins_pingroup_on_multiple_pins(
         self, edb_examples, pec_boundary: bool, positive_pin_names: Sequence[str]
     ):
+        EXPECTED_TERMINAL_TYPE = "PinGroupTerminal" if len(positive_pin_names) > 1 else "PadstackInstanceTerminal"
         edbapp = edb_examples.get_si_verse()
         component_name = "U1"
         edbcomp = edbapp.components[component_name]
@@ -2019,7 +2020,10 @@ class TestClass:
         )
         assert len(edbapp.excitations) == 2
         for excitation in edbapp.excitations.values():
-            assert excitation.terminal_type == "PinGroupTerminal"
+            if excitation.is_reference_terminal:
+                assert excitation.terminal_type == "PinGroupTerminal"
+            else:
+                assert excitation.terminal_type == EXPECTED_TERMINAL_TYPE
 
     def test_create_circuit_port_on_component_pins_pingroup_on_single_pin(self, edb_examples):
         edbapp = edb_examples.get_si_verse()

--- a/tests/legacy/system/test_edb.py
+++ b/tests/legacy/system/test_edb.py
@@ -1917,7 +1917,7 @@ class TestClass:
         reference_net_names = ["GND"]
         assert edbapp.components.create_port_on_component(
             component="U10",
-            net_list=positive_net_names if nets_mode == "str" else [edbapp.nets[net] for net in positive_net_list],
+            net_list=(positive_net_names if nets_mode == "str" else [edbapp.nets[net] for net in positive_net_list]),
             port_type=SourceType.CircPort,
             do_pingroup=False,
             reference_net=(
@@ -2002,16 +2002,20 @@ class TestClass:
         )
         assert len(edbapp.excitations) == 2
 
-    def test_create_circuit_port_on_component_pins_pingroup_on_multiple_pins(self, edb_examples):
+    @pytest.mark.parametrize("positive_pin_names", (["R20", "R21", "T20"], ["R20"]))
+    @pytest.mark.parametrize("pec_boundary", (False, True))
+    def test_create_circuit_port_on_component_pins_pingroup_on_multiple_pins(
+        self, edb_examples, pec_boundary: bool, positive_pin_names: Sequence[str]
+    ):
         edbapp = edb_examples.get_si_verse()
         component_name = "U1"
         edbcomp = edbapp.components[component_name]
-        positive_pin_names = ["R20", "R21", "T20"]
         reference_pin_names = ["N21", "R19", "T21"]
         assert edbapp.components.create_port_on_pins(
             refdes=edbcomp,
             pins=positive_pin_names,
             reference_pins=reference_pin_names,
+            pec_boundary=pec_boundary,
         )
         assert len(edbapp.excitations) == 2
         for excitation in edbapp.excitations.values():


### PR DESCRIPTION
Fix create_port_on_pins with multiple positive pins, an incorrect conditional was resulting in the creation of pin ports instead of pin group ports in this case.