### PR TITLE
CI: Add mandatory token to Github release job

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -417,6 +417,7 @@ jobs:
         uses: ansys/actions/release-github@v8
         with:
           library-name: ${{ env.PACKAGE_NAME }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   upload-dev-docs:
     name: Upload dev documentation


### PR DESCRIPTION
As title says.