### PR TITLE
FIX: Pass runtime candidate as runtime_spec instead of runtime_config when DOTNET_ROOT is set

### DIFF
--- a/src/pyedb/__init__.py
+++ b/src/pyedb/__init__.py
@@ -44,7 +44,7 @@ deprecation_warning()
 #
 
 pyedb_path = os.path.dirname(__file__)
-__version__ = "0.50.dev0"
+__version__ = "0.51.dev0"
 version = __version__
 
 #

--- a/src/pyedb/dotnet/clr_module.py
+++ b/src/pyedb/dotnet/clr_module.py
@@ -81,7 +81,7 @@ if is_linux:  # pragma: no cover
                 )
             runtime_spec = candidates[0]
     # Use specific .NET core runtime
-    if dotnet_root is not None and runtime_config is not None:
+    if dotnet_root is not None and (runtime_config is not None or runtime_spec is not None):
         try:
             load(
                 "coreclr",

--- a/src/pyedb/dotnet/clr_module.py
+++ b/src/pyedb/dotnet/clr_module.py
@@ -38,6 +38,7 @@ if is_linux:  # pragma: no cover
 
     dotnet_root = None
     runtime_config = None
+    runtime_spec = None
     # Use system .NET core runtime or fall back to dotnetcore2
     if os.environ.get("DOTNET_ROOT") is None:
         try:
@@ -78,11 +79,16 @@ if is_linux:  # pragma: no cover
                     "Please ensure that .NET SDK is correctly installed or "
                     "that DOTNET_ROOT is correctly set."
                 )
-            runtime_config = candidates[0]
+            runtime_spec = candidates[0]
     # Use specific .NET core runtime
     if dotnet_root is not None and runtime_config is not None:
         try:
-            load("coreclr", runtime_config=str(runtime_config), dotnet_root=str(dotnet_root))
+            load(
+                "coreclr",
+                runtime_config=str(runtime_config) if runtime_config else None,
+                runtime_spec=runtime_spec,
+                dotnet_root=str(dotnet_root),
+            )
             os.environ["DOTNET_ROOT"] = dotnet_root.as_posix()
             if "mono" not in os.getenv("LD_LIBRARY_PATH", ""):
                 warnings.warn("LD_LIBRARY_PATH needs to be setup to use pyedb.")


### PR DESCRIPTION
When `DOTNET_ROOT` is set, pass the selected candidate as the `runtime_spec` argument of `pythonnet.load` instead of the
`runtime_config` argument.  This avoids a failure since the candidates are selected from a list of `DotNetCoreRuntimeSpec` instances.

Fixes #1306 