### PR TITLE
FEAT: Adding import - export layout component

### DIFF
--- a/src/pyedb/grpc/edb.py
+++ b/src/pyedb/grpc/edb.py
@@ -70,6 +70,9 @@ import warnings
 from zipfile import ZipFile as zpf
 
 from ansys.edb.core.geometry.polygon_data import PolygonData as GrpcPolygonData
+from ansys.edb.core.hierarchy.layout_component import (
+    LayoutComponent as GrpcLayoutComponent,
+)
 import ansys.edb.core.layout.cell
 from ansys.edb.core.simulation_setup.siwave_dcir_simulation_setup import (
     SIWaveDCIRSimulationSetup as GrpcSIWaveDCIRSimulationSetup,
@@ -3834,3 +3837,38 @@ class Edb(EdbInit):
         else:
             self.logger.info("Comparison correctly completed")
             return True
+
+    def import_layout_component(self, component_path) -> GrpcLayoutComponent:
+        """Import a layout component inside the current layout and place it at the origin.
+        This feature is only supported with PyEDB gRPC. Encryption is not yet supported.
+
+        Parameters
+        ----------
+        component_path : str
+            Layout component path (.aedbcomp file).
+
+        Returns
+        -------
+            class:`LayoutComponent <ansys.edb.core.hierarchy.layout_component.LayoutComponent>`.
+        """
+
+        return GrpcLayoutComponent.import_layout_component(layout=self.active_layout, aedb_comp_path=component_path)
+
+    def export_layout_component(self, component_path) -> bool:
+        """Export a layout component from the current layout.
+        This feature is only supported with PyEDB gRPC. Encryption is not yet supported.
+
+        Parameters
+        ----------
+        component_path : str
+            Layout component path (.aedbcomp file).
+
+        Returns
+        -------
+        bool
+            `True` if layout component is successfully exported, `False` otherwise.
+        """
+
+        return GrpcLayoutComponent.export_layout_component(
+            layout=self.active_layout, output_aedb_comp_path=component_path
+        )

--- a/tests/grpc/system/test_edb.py
+++ b/tests/grpc/system/test_edb.py
@@ -1971,3 +1971,13 @@ class TestClass:
         assert edbapp.compare(edb_base)
         folder = edbapp.edbpath[:-5] + "_compare_results"
         assert os.path.exists(folder)
+
+    def test_create_layout_component(self, edb_examples):
+        edbapp = edb_examples.get_si_verse()
+        out_file = os.path.join(self.local_scratch.path, "test.aedbcomp")
+        edbapp.export_layout_component(component_path=out_file)
+        assert os.path.isfile(out_file)
+        edbapp.close()
+        edbapp = Edb(edbversion=desktop_version)
+        layout_comp = edbapp.import_layout_component(out_file)
+        assert not layout_comp.cell_instance.is_null


### PR DESCRIPTION
This PR is adding import - export layout component. This feature is only supported with gRPC API.