### PR TITLE
BUILD: Bump pydantic upper bound to <2.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "dotnetcore2 ==3.1.23;platform_system=='Linux'",
     "numpy>=1.20.0,<3",
     "pandas>=1.1.0,<2.3",
-    "pydantic>=2.6.4,<2.11",
+    "pydantic>=2.6.4,<2.12",
     "Rtree >= 1.2.0",
     "toml == 0.10.2",
     "shapely",


### PR DESCRIPTION
As title says.

Close #1337 

@svandenb-dev Pydantic is used for `Material` related classes. I assumed that it would be used in other classes but that is not the case. If you don't plan to use it, let me know and we could just remove this dependency & refactor the material class to work with something builtin. 