### PR TITLE
BUILD: Remove ansys-edb-api dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,8 @@ dependencies = [
     "shapely",
     "scikit-rf",
     "ansys-edb-core>=0.2.0",
-    "ansys-api-edb>=0.2.0",
     "psutil",
-    ]
+]
 
 [project.optional-dependencies]
 tests = [


### PR DESCRIPTION
I think the handling of the `ansys-edb-api` package should be left to `ansys-edb-core` since we don't directly leverage the former package. Avoiding this will also help with dependency resolution conflicts in the pyansys meta package.

If there is something wrong with the version of the `ansys-edb-api`, an issue should be opened [here](https://github.com/ansys/pyedb-core/issues) so that the concerned maintainers handle the dependency issue.

FYI, here is the kind of issues that we are having:
```
 The conflict is caused by:
    pyedb 0.56.dev0 depends on ansys-api-edb>=0.2.0
    ansys-edb-core 0.3.0.dev0 depends on ansys-api-edb==0.2.dev6
```

The maintainers of `ansys-edb-core` should be doing a new release to correctly manage the versions requirements with `ansys-api-edb` soon :) Pinging @drewm102 for visibility