### PR TITLE
FIX: bug #1447

### DIFF
--- a/src/pyedb/dotnet/database/components.py
+++ b/src/pyedb/dotnet/database/components.py
@@ -1002,12 +1002,6 @@ class Components(object):
         ]
         pin_layers = cmp_pins[0].GetPadstackDef().GetData().GetLayerNames()
         if port_type == SourceType.CoaxPort:
-            if not solder_balls_height:
-                solder_balls_height = self.instances[component.GetName()].solder_ball_height
-            if not solder_balls_size:
-                solder_balls_size = self.instances[component.GetName()].solder_ball_diameter[0]
-            if not solder_balls_mid_size:
-                solder_balls_mid_size = self.instances[component.GetName()].solder_ball_diameter[1]
             if not ref_pins:
                 self._logger.error(
                     "No reference pins found on component. You might consider"
@@ -1016,40 +1010,51 @@ class Components(object):
                 )
                 return False
             pad_params = self._padstack.get_pad_parameters(pin=cmp_pins[0], layername=pin_layers[0], pad_type=0)
-            if not pad_params[0] == 7:
-                if not solder_balls_size:  # pragma no cover
-                    sball_diam = min([self._pedb.edb_value(val).ToDouble() for val in pad_params[1]])
-                    sball_mid_diam = sball_diam
+
+            # If at least one of the solderball arguments is not None, calculate the rest and set solderballs
+            if not (not solder_balls_height and not solder_balls_size and not solder_balls_mid_size):
+                if not solder_balls_height:
+                    solder_balls_height = self.instances[component.GetName()].solder_ball_height
+                if not solder_balls_size:
+                    solder_balls_size = self.instances[component.GetName()].solder_ball_diameter[0]
+                if not solder_balls_mid_size:
+                    solder_balls_mid_size = self.instances[component.GetName()].solder_ball_diameter[1]
+
+                if not pad_params[0] == 7:
+                    if not solder_balls_size:  # pragma no cover
+                        sball_diam = min([self._pedb.edb_value(val).ToDouble() for val in pad_params[1]])
+                        sball_mid_diam = sball_diam
+                    else:  # pragma no cover
+                        sball_diam = solder_balls_size
+                        if solder_balls_mid_size:
+                            sball_mid_diam = solder_balls_mid_size
+                        else:
+                            sball_mid_diam = solder_balls_size
+                    if not solder_balls_height:  # pragma no cover
+                        solder_balls_height = 2 * sball_diam / 3
                 else:  # pragma no cover
-                    sball_diam = solder_balls_size
+                    if not solder_balls_size:
+                        bbox = pad_params[1]
+                        sball_diam = min([abs(bbox[2] - bbox[0]), abs(bbox[3] - bbox[1])]) * 0.8
+                    else:
+                        sball_diam = solder_balls_size
+                    if not solder_balls_height:
+                        solder_balls_height = 2 * sball_diam / 3
                     if solder_balls_mid_size:
                         sball_mid_diam = solder_balls_mid_size
                     else:
-                        sball_mid_diam = solder_balls_size
-                if not solder_balls_height:  # pragma no cover
-                    solder_balls_height = 2 * sball_diam / 3
-            else:  # pragma no cover
-                if not solder_balls_size:
-                    bbox = pad_params[1]
-                    sball_diam = min([abs(bbox[2] - bbox[0]), abs(bbox[3] - bbox[1])]) * 0.8
-                else:
-                    sball_diam = solder_balls_size
-                if not solder_balls_height:
-                    solder_balls_height = 2 * sball_diam / 3
-                if solder_balls_mid_size:
-                    sball_mid_diam = solder_balls_mid_size
-                else:
-                    sball_mid_diam = sball_diam
-            sball_shape = "Cylinder"
-            if not sball_diam == sball_mid_diam:
-                sball_shape = "Spheroid"
-            self.set_solder_ball(
-                component=component,
-                sball_height=solder_balls_height,
-                sball_diam=sball_diam,
-                sball_mid_diam=sball_mid_diam,
-                shape=sball_shape,
-            )
+                        sball_mid_diam = sball_diam
+                sball_shape = "Cylinder"
+                if not sball_diam == sball_mid_diam:
+                    sball_shape = "Spheroid"
+                self.set_solder_ball(
+                    component=component,
+                    sball_height=solder_balls_height,
+                    sball_diam=sball_diam,
+                    sball_mid_diam=sball_mid_diam,
+                    shape=sball_shape,
+                )
+
             for pin in cmp_pins:
                 self._padstack.create_coax_port(padstackinstance=pin, name=port_name)
 


### PR DESCRIPTION
Change `create_port_on_component` function so that if no solderball size arguments are given, no solderball is created.
Fixes #1447.