### PR TITLE
REFACTOR: Replace ``random`` by ``secrets`` for random number generation and sampling

### DIFF
--- a/src/pyedb/generic/data_handlers.py
+++ b/src/pyedb/generic/data_handlers.py
@@ -2,8 +2,8 @@
 from decimal import Decimal
 import json
 import math
-import random
 import re
+import secrets
 import string
 
 from pyedb.generic.general_methods import settings
@@ -54,7 +54,7 @@ def random_string(length=6, only_digits=False, char_set=None):  # pragma: no cov
             char_set = string.digits
         else:
             char_set = string.ascii_uppercase + string.digits
-    random_str = "".join(random.choice(char_set) for _ in range(int(length)))
+    random_str = "".join(secrets.choice(char_set) for _ in range(int(length)))
     return random_str
 
 

--- a/src/pyedb/generic/filesystem.py
+++ b/src/pyedb/generic/filesystem.py
@@ -1,5 +1,5 @@
 import os
-import random
+import secrets
 import shutil
 import string
 
@@ -44,7 +44,10 @@ class Scratch:
         self._volatile = volatile
         self._cleaned = True
         char_set = string.ascii_uppercase + string.digits
-        self._scratch_path = os.path.normpath(os.path.join(local_path, "scratch" + "".join(random.sample(char_set, 6))))
+        generator = secrets.SystemRandom()
+        self._scratch_path = os.path.normpath(
+            os.path.join(local_path, "scratch" + "".join(secrets.SystemRandom.sample(generator, char_set, 6)))
+        )
         if os.path.exists(self._scratch_path):
             try:
                 self.remove()

--- a/src/pyedb/generic/general_methods.py
+++ b/src/pyedb/generic/general_methods.py
@@ -35,8 +35,8 @@ import itertools
 import logging
 import math
 import os
-import random
 import re
+import secrets
 import string
 import sys
 import tempfile
@@ -254,7 +254,7 @@ def generate_unique_name(rootname, suffix="", n=6):
 
     """
     char_set = string.ascii_uppercase + string.digits
-    uName = "".join(random.choice(char_set) for _ in range(n))
+    uName = "".join(secrets.choice(char_set) for _ in range(n))
     unique_name = rootname + "_" + uName
     if suffix:
         unique_name += "_" + suffix

--- a/src/pyedb/grpc/rpc_session.py
+++ b/src/pyedb/grpc/rpc_session.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 import os
-from random import randint
+import secrets
 import sys
 import time
 
@@ -170,11 +170,12 @@ class RpcSession:
     @staticmethod
     def __get_random_free_port():
         """"""
-        port = randint(49152, 65535)
+        secure_random = secrets.SystemRandom()
+        port = secure_random.randint(49152, 65535)
         while True:
             used_ports = [conn.laddr[1] for conn in psutil.net_connections()]
             if port in used_ports:
-                port = randint(49152, 65535)
+                port = secure_random.randint(49152, 65535)
             else:
                 break
         return port

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@
 import json
 import os
 from pathlib import Path
-import random
+import secrets
 import shutil
 import string
 import tempfile
@@ -66,7 +66,8 @@ bom_example = "bom_example.csv"
 
 def generate_random_string(length):
     characters = string.ascii_letters + string.digits
-    random_string = "".join(random.sample(characters, length))
+    generator = secrets.SystemRandom()
+    random_string = "".join(secrets.SystemRandom.sample(generator, characters, length))
     return random_string
 
 


### PR DESCRIPTION
This PR provides an alternative syntax using the ``secrets`` module instead of ``random`` in all instances where the latter was used. The changes introduced therefore make it possible to avoid using the ``random`` module throughout the entire ``pyedb`` project.

The motivation for this update can be read from [here](https://docs.python.org/3/library/secrets.html): "``secrets`` should be used in preference to the default pseudo-random number generator in the ``random`` module, which is designed for modelling and simulation, not security or cryptography".