### PR TITLE
REFACTOR: Raise errors instead of using ``assert`` in code outside of tests

### DIFF
--- a/src/pyedb/dotnet/database/Variables.py
+++ b/src/pyedb/dotnet/database/Variables.py
@@ -181,13 +181,15 @@ class CSVDataset:
                 if variable in key_string:
                     found_variable = True
                     break
-            assert found_variable, "Input string {} is not a key of the data dictionary.".format(variable)
+            if not found_variable:
+                raise KeyError(f"Input string {variable} is not a key of the data dictionary.")
             data_out._data[variable] = self._data[key_string]
             data_out._header.append(variable)
         return data_out
 
     def __add__(self, other):  # pragma: no cover
-        assert self.number_of_columns == other.number_of_columns, "Inconsistent number of columns"
+        if self.number_of_columns != other.number_of_columns:
+            raise ValueError("Number of columns is inconsistent.")
         # Create a new object to return, avoiding changing the original inputs
         new_dataset = CSVDataset()
         # Add empty columns to new_dataset
@@ -222,7 +224,8 @@ class CSVDataset:
             for column in other.data:
                 self._data[column] = []
 
-        assert self.number_of_columns == other.number_of_columns, "Inconsistent number of columns"
+        if self.number_of_columns != other.number_of_columns:
+            raise ValueError("Number of columns is inconsistent.")
 
         # Append the data from 'other'
         for column, row_data in other.data.items():
@@ -1341,9 +1344,10 @@ class Variable(object):
             self._value = self._calculated_value
         # If units have been specified, check for a conflict and otherwise use the specified unit system
         if units:
-            assert not self._units, "The unit specification {} is inconsistent with the identified units {}.".format(
-                specified_units, self._units
-            )
+            if self._units and self._units != specified_units:
+                raise RuntimeError(
+                    f"The unit specification {specified_units} is inconsistent with the identified units {self._units}."
+                )
             self._units = specified_units
 
         if not si_value and is_number(self._value):
@@ -1730,9 +1734,10 @@ class Variable(object):
 
         """
         new_unit_system = unit_system(units)
-        assert (
-            new_unit_system == self.unit_system
-        ), "New unit system {0} is inconsistent with the current unit system {1}."
+        if new_unit_system != self.unit_system:
+            raise ValueError(
+                f"New unit system {new_unit_system} is inconsistent with the current unit system {self.unit_system}."
+            )
         self._units = units
         return self
 
@@ -1803,7 +1808,8 @@ class Variable(object):
         >>> assert result_3.unit_system == "Power"
 
         """
-        assert is_number(other) or isinstance(other, Variable), "Multiplier must be a scalar quantity or a variable."
+        if not is_number(other) and not isinstance(other, Variable):
+            raise ValueError("Multiplier must be a scalar quantity or a variable.")
         if is_number(other):
             result_value = self.numeric_value * other
             result_units = self.units
@@ -1847,10 +1853,10 @@ class Variable(object):
         >>> assert result.unit_system == "Current"
 
         """
-        assert isinstance(other, Variable), "You can only add a variable with another variable."
-        assert (
-            self.unit_system == other.unit_system
-        ), "Only ``Variable`` objects with the same unit system can be added."
+        if not isinstance(other, Variable):
+            raise ValueError("You can only add a variable with another variable.")
+        if self.unit_system != other.unit_system:
+            raise ValueError("Only Variable objects with the same unit system can be added.")
         result_value = self.value + other.value
         result_units = SI_UNITS[self.unit_system]
         # If the units of the two operands are different, return SI-Units
@@ -1888,10 +1894,10 @@ class Variable(object):
         >>> assert result_2.unit_system == "Current"
 
         """
-        assert isinstance(other, Variable), "You can only subtract a variable from another variable."
-        assert (
-            self.unit_system == other.unit_system
-        ), "Only ``Variable`` objects with the same unit system can be subtracted."
+        if not isinstance(other, Variable):
+            raise ValueError("You can only subtract a variable from another variable.")
+        if self.unit_system != other.unit_system:
+            raise ValueError("Only Variable objects with the same unit system can be subtracted.")
         result_value = self.value - other.value
         result_units = SI_UNITS[self.unit_system]
         # If the units of the two operands are different, return SI-Units
@@ -1933,7 +1939,8 @@ class Variable(object):
         >>> assert result_1.unit_system == "Current"
 
         """
-        assert is_number(other) or isinstance(other, Variable), "Divisor must be a scalar quantity or a variable."
+        if not is_number(other) and not isinstance(other, Variable):
+            raise ValueError("Divisor must be a scalar quantity or a variable.")
         if is_number(other):
             result_value = self.numeric_value / other
             result_units = self.units

--- a/src/pyedb/generic/data_handlers.py
+++ b/src/pyedb/generic/data_handlers.py
@@ -85,9 +85,8 @@ def unique_string_list(element_list, only_string=True):  # pragma: no cover
                 pass
             raise Exception(error_message)
 
-        if only_string:
-            non_string_entries = [x for x in element_list if type(x) is not str]
-            assert not non_string_entries, "Invalid list entries {} are not a string!".format(non_string_entries)
+        if only_string and any(not isinstance(x, str) for x in element_list):
+            raise TypeError("Invalid list entries, some elements are not of type string.")
 
     return element_list
 
@@ -104,10 +103,10 @@ def string_list(element_list):  # pragma: no cover
     -------
 
     """
+    if not isinstance(element_list, (str, list)):
+        raise TypeError("Input must be a list or a string")
     if isinstance(element_list, str):
         element_list = [element_list]
-    else:
-        assert isinstance(element_list, str), "Input must be a list or a string"
     return element_list
 
 

--- a/src/pyedb/modeler/geometry_operators.py
+++ b/src/pyedb/modeler/geometry_operators.py
@@ -1456,9 +1456,8 @@ class GeometryOperators(object):
         cross = GeometryOperators.v_cross(va, vb)
         if GeometryOperators.v_norm(cross) < tol:
             return math.pi
-        assert GeometryOperators.is_collinear(cross, vn), (
-            "vn must be the normal to the " "plane containing va and vb."
-        )  # pragma: no cover
+        if not GeometryOperators.is_collinear(cross, vn):
+            raise ValueError("vn must be the normal to the plane containing va and vb")  # pragma: no cover
 
         vnn = GeometryOperators.normalize_vector(vn)
         if right_handed:
@@ -1672,10 +1671,11 @@ class GeometryOperators(object):
         float
             ``True`` if the segment intersect the polygon. ``False`` otherwise.
         """
-        assert len(a) == 2, "point must be a list in the form [x, y]"
-        assert len(b) == 2, "point must be a list in the form [x, y]"
+        if len(a) != 2 or len(b) != 2:
+            raise ValueError("Point must be a list in the form [x, y]")
         pl = len(polygon[0])
-        assert len(polygon[1]) == pl, "Polygon x and y lists must be the same length"
+        if len(polygon[1]) != pl:
+            raise ValueError("The two sublists in polygon must have the same length")
 
         a_in = GeometryOperators.is_point_in_polygon(a, polygon)
         b_in = GeometryOperators.is_point_in_polygon(b, polygon)

--- a/src/pyedb/siwave.py
+++ b/src/pyedb/siwave.py
@@ -129,17 +129,15 @@ class Siwave(object):  # pragma no cover
             self._main.AEDTVersion = self._main.oSiwave.GetVersion()[0:6]
             self._main.oSiwave.RestoreWindow()
             specified_version = self.current_version
-            assert specified_version in self.version_keys, "Specified version {} is not known.".format(
-                specified_version
-            )
+            if specified_version not in self.version_keys:
+                raise ValueError("Specified version {} is not known.".format(specified_version))
             version_key = specified_version
             base_path = os.getenv(self._version_ids[specified_version])
             self._main.sDesktopinstallDirectory = base_path
         else:
             if specified_version:
-                assert specified_version in self.version_keys, "Specified version {} is not known.".format(
-                    specified_version
-                )
+                if specified_version not in self.version_keys:
+                    raise ValueError("Specified version {} is not known.".format(specified_version))
                 version_key = specified_version
             else:
                 version_key = self.current_version


### PR DESCRIPTION
This PR provides refactoring for raising errors instead of using ``assert`` in code. Use of ``assert`` in test files is not regarded as problematic and is left unchanged. The modifications introduced remove all instances of ``assert`` in code outside from test files throughout the entire ``pyedb`` project.
The motivation for this update can be read from [here](https://bandit.readthedocs.io/en/latest/plugins/b101_assert_used.html): In some cases, ``assert`` clauses may be removed upon code compilation, resulting in the loss of the protections implemented. Therefore, raising semantically meaningful errors should be preferred.

For these changes, similar updates previously performed in ``pyaedt`` have been leveraged as follows:
* ``src/pyedb/dotnet/database/Variables.py`` was updated following changes made to the ``pyaedt`` file ``src/ansys/aedt/core/application/variables.py`` in https://github.com/ansys/pyaedt/pull/4554 also considering updates later introduced to that same file in https://github.com/ansys/pyaedt/pull/5272,
* ``src/pyedb/generic/data_handlers.py`` was updated following changes made to the ``pyaedt`` file ``src/ansys/aedt/core/generic/data_handlers.py`` in https://github.com/ansys/pyaedt/pull/5995,
* ``src/pyedb/modeler/geometry_operators.py`` was updated following changes made to the ``pyaedt`` file ``src/ansys/aedt/core/modeler/geometry_operators.py`` in https://github.com/ansys/pyaedt/pull/5579,
* ``src/pyedb/siwave.py`` was updated following implementation of similar checks on version in the ``pyaedt`` files ``src/ansys/aedt/core/desktop.py`` and ``src/ansys/aedt/core/filtersolutions_core/dll_interface.py``.