### PR TITLE
REFACTOR: Replace ``xml`` imports and methods with their ``defusedxml`` equivalents for XML parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "scikit-rf",
     "ansys-edb-core>=0.2.0",
     "psutil",
+    "defusedxml>=0.7,<8.0",
 ]
 
 [project.optional-dependencies]

--- a/src/pyedb/dotnet/database/edb_data/control_file.py
+++ b/src/pyedb/dotnet/database/edb_data/control_file.py
@@ -27,6 +27,8 @@ import subprocess
 import sys
 import xml
 
+from defusedxml.ElementTree import parse as defused_parse
+
 from pyedb.generic.general_methods import ET, env_path, env_value, is_linux
 from pyedb.generic.settings import settings
 from pyedb.misc.aedtlib_personalib_install import write_pretty_xml
@@ -1210,7 +1212,7 @@ class ControlFile:
         -------
         bool
         """
-        tree = ET.parse(xml_input)
+        tree = defused_parse(xml_input)
         root = tree.getroot()
         for el in root:
             if el.tag == "Stackup":

--- a/src/pyedb/dotnet/database/stackup.py
+++ b/src/pyedb/dotnet/database/stackup.py
@@ -33,6 +33,8 @@ import logging
 import math
 import warnings
 
+from defusedxml.ElementTree import parse as defused_parse
+
 from pyedb.dotnet.database.edb_data.layer_data import (
     LayerEdbClass,
     StackupLayerEdbClass,
@@ -2245,7 +2247,7 @@ class Stackup(LayerCollection):
         if not colors:
             self._pedb.logger.error("Matplotlib is needed. Please, install it first.")
             return False
-        tree = ET.parse(file_path)
+        tree = defused_parse(file_path)
         root = tree.getroot()
         stackup = root.find("Stackup")
         stackup_dict = {}

--- a/src/pyedb/generic/general_methods.py
+++ b/src/pyedb/generic/general_methods.py
@@ -52,7 +52,7 @@ _pythonver = sys.version_info[0]
 
 
 try:
-    import xml.etree.cElementTree as ET
+    import xml.etree.cElementTree as ET  # nosec B405
 
     ET.VERSION
 except ImportError:

--- a/src/pyedb/grpc/database/control_file.py
+++ b/src/pyedb/grpc/database/control_file.py
@@ -27,6 +27,8 @@ import subprocess
 import sys
 from typing import Any, Dict, List, Optional, Union
 
+from defusedxml.ElementTree import parse as defused_parse
+
 from pyedb.generic.general_methods import ET, env_path, env_value, is_linux
 from pyedb.generic.settings import settings
 from pyedb.misc.aedtlib_personalib_install import write_pretty_xml
@@ -1673,7 +1675,7 @@ class ControlFile:
         bool
             ``True`` if successful, ``False`` otherwise.
         """
-        tree = ET.parse(xml_input)
+        tree = defused_parse(xml_input)
         root = tree.getroot()
         for el in root:
             if el.tag == "Stackup":

--- a/src/pyedb/grpc/database/stackup.py
+++ b/src/pyedb/grpc/database/stackup.py
@@ -50,6 +50,7 @@ from ansys.edb.core.layer.layer_collection import LayerCollection as GrpcLayerCo
 from ansys.edb.core.layer.layer_collection import LayerTypeSet as GrpcLayerTypeSet
 from ansys.edb.core.layer.stackup_layer import StackupLayer as GrpcStackupLayer
 from ansys.edb.core.layout.mcad_model import McadModel as GrpcMcadModel
+from defusedxml.ElementTree import parse as defused_parse
 
 from pyedb.generic.general_methods import ET, generate_unique_name
 from pyedb.grpc.database.layers.layer import Layer
@@ -2207,7 +2208,7 @@ class Stackup(LayerCollection):
         if not colors:
             self._pedb.logger.error("Matplotlib is needed. Please, install it first.")
             return False
-        tree = ET.parse(file_path)
+        tree = defused_parse(file_path)
         root = tree.getroot()
         stackup = root.find("Stackup")
         stackup_dict = {}

--- a/src/pyedb/grpc/database/utility/xml_control_file.py
+++ b/src/pyedb/grpc/database/utility/xml_control_file.py
@@ -26,6 +26,8 @@ import re
 import subprocess
 import sys
 
+from defusedxml.ElementTree import parse as defused_parse
+
 from pyedb.generic.general_methods import ET, env_path, env_value, is_linux
 from pyedb.generic.settings import settings
 from pyedb.misc.aedtlib_personalib_install import write_pretty_xml
@@ -1185,7 +1187,7 @@ class ControlFile:
         -------
         bool
         """
-        tree = ET.parse(xml_input)
+        tree = defused_parse(xml_input)
         root = tree.getroot()
         for el in root:
             if el.tag == "Stackup":

--- a/src/pyedb/misc/aedtlib_personalib_install.py
+++ b/src/pyedb/misc/aedtlib_personalib_install.py
@@ -20,8 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from xml.dom.minidom import parseString
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
+from defusedxml.minidom import parseString
 
 
 def write_pretty_xml(root, file_path):

--- a/src/pyedb/misc/siw_feature_config/emc_rule_checker_settings.py
+++ b/src/pyedb/misc/siw_feature_config/emc_rule_checker_settings.py
@@ -23,6 +23,7 @@
 from copy import deepcopy as copy
 import json
 
+from defusedxml.ElementTree import parse as defused_parse
 import numpy as np
 
 from pyedb.generic.general_methods import ET
@@ -78,7 +79,7 @@ class EMCRuleCheckerSettings:
         fpath: str
             Path to file.
         """
-        tree = ET.parse(fpath)
+        tree = defused_parse(fpath)
         root = tree.getroot()
 
         self.tag_library = TagLibrary(root.find("TagLibrary"))

--- a/src/pyedb/misc/siw_feature_config/xtalk_scan/scan_config.py
+++ b/src/pyedb/misc/siw_feature_config/xtalk_scan/scan_config.py
@@ -22,7 +22,6 @@
 
 from enum import Enum
 import os
-import xml.etree as ET
 
 from pyedb.generic.general_methods import ET
 from pyedb.misc.siw_feature_config.xtalk_scan.fd_xtalk_scan_config import (

--- a/tests/system/test_siwave_features.py
+++ b/tests/system/test_siwave_features.py
@@ -16,9 +16,9 @@
 
 import os
 
+from defusedxml.ElementTree import parse as defused_parse
 import pytest
 
-from pyedb.generic.general_methods import ET
 from tests.system.base_test_class import BaseTestClass
 
 pytestmark = [pytest.mark.system, pytest.mark.legacy]
@@ -41,7 +41,7 @@ class TestClass(BaseTestClass):
             )
         xtalk_scan.file_path = os.path.join(self.local_scratch.path, "test_impedance_scan.xml")
         assert xtalk_scan.write_xml()
-        tree = ET.parse(xtalk_scan.file_path)
+        tree = defused_parse(xtalk_scan.file_path)
         root = tree.getroot()
         nets = [child for child in root[0] if "SingleEndedNets" in child.tag][0]
         assert len(nets) == 342
@@ -65,7 +65,7 @@ class TestClass(BaseTestClass):
 
         xtalk_scan.file_path = os.path.join(self.local_scratch.path, "test_impedance_scan.xml")
         assert xtalk_scan.write_xml()
-        tree = ET.parse(xtalk_scan.file_path)
+        tree = defused_parse(xtalk_scan.file_path)
         root = tree.getroot()
         nets = [child for child in root[0] if "SingleEndedNets" in child.tag][0]
         assert len(nets) == 342
@@ -93,7 +93,7 @@ class TestClass(BaseTestClass):
             xtalk_scan.time_xtalk_scan.add_receiver_pin(name=pin.name, ref_des="U1", impedance=80.0)
         xtalk_scan.file_path = os.path.join(self.local_scratch.path, "test_impedance_scan.xml")
         assert xtalk_scan.write_xml()
-        tree = ET.parse(xtalk_scan.file_path)
+        tree = defused_parse(xtalk_scan.file_path)
         root = tree.getroot()
         nets = [child for child in root[0] if "SingleEndedNets" in child.tag][0]
         assert len(nets) == 342


### PR DESCRIPTION
The purpose of this PR is to improve security around XML file parsing in the ``pyedb`` project. For these operations, methods from the ``defusedxml`` package should be used instead of those from the ``xml`` module. To this end, the ``defusedxml`` package is added as a dependency to ``pyedb`` in the ``pyproject.toml`` file with the same specifications as for ``pyaedt``.
The motivation for these changes is provided [here](https://bandit.readthedocs.io/en/latest/blacklists/blacklist_calls.html#b313-b319-xml), [here](https://bandit.readthedocs.io/en/latest/blacklists/blacklist_imports.html#b405-import-xml-etree), or [here](https://bandit.readthedocs.io/en/latest/blacklists/blacklist_imports.html#b408-import-xml-minidom): "Using various ``xml`` methods to parse untrusted XML data is known to be vulnerable to XML attacks. Methods should be replaced with their ``defusedxml`` equivalents."

However, as discussed in an issue of the ``defusedxml`` project (https://github.com/tiran/defusedxml/issues/48), it should be noted that: "The ``defusedxml`` modules are not drop-in replacements for their stdlib counterparts. The modules only provide functions and classes related to parsing and loading XML. For all other features, use the classes, functions, and constants from the stdlib modules."

Thus, the updates introduced by this PR are performed as follows:
- Changes to the file ``src/pyedb/misc/aedtlib_personalib_install.py``: Here, the methods of the ``xml`` module are simply replaced by their ``defusedxml`` equivalents.
- Changes to the file ``src/pyedb/generic/general_methods.py``: In fact, no change are made here because importing the ``cElementTree`` module from ``xml.etree`` in this file is intended to enable the import of this module using ``from pyedb.generic.general_methods import ET`` in many other files in the project, where in the vast majority of cases no XML file parsing or loading is taking place. Still, in order to avoid security warning, a flag ``# nosec B405`` (see link above) is added. However, in each file importing the module ``cElementTree`` through ``general_methods``, a distinction is made when necessary (affecting 7 files in total) between XML parsing operations (introducing for this the ``parse`` method of ``defusedxml.ElementTree``) and other common XML data manipulation operations that can be performed safely using the ``xml`` module as previously.

Finally, for reference and as an example, this topic was notably addressed on ``pyaedt`` in the following two PRs: https://github.com/ansys/pyaedt/pull/5365 and https://github.com/ansys/pyaedt/pull/5378