### PR TITLE
REFACTOR: Apply security improvements to previously missed occurrence of ``subprocess.run()``

### DIFF
--- a/src/pyedb/generic/process.py
+++ b/src/pyedb/generic/process.py
@@ -48,6 +48,11 @@ class SiwaveSolve(object):
     def solve_siwave(self, edbpath, analysis_type):
         """Solve an SIWave setup. Only non-graphical batch mode is supported.
 
+        .. warning::
+            Do not execute this function with untrusted function argument, environment
+            variables or pyedb global settings.
+            See the :ref:`security guide<ref_security_consideration>` for details.
+
         Parameters
         ----------
         analysis_type: str
@@ -67,8 +72,8 @@ class SiwaveSolve(object):
             "-useSubdir",
         ]
         try:
-            subprocess.run(command, check=True)
-        except subprocess.CalledProcessError as e:
+            subprocess.run(command, check=True)  # nosec
+        except subprocess.CalledProcessError as e:  # nosec
             raise RuntimeError(f"An error occurred when launching the solver. Please check input paths") from e
 
     def solve(self, num_of_cores=4):


### PR DESCRIPTION
This PR is a minimal follow-up to #1530, which aimed at improving security around the use of ``subprocess`` for executing commands inside scripts of ``pyedb``.

Simultaneously with the changes made in the context of #1530, a new method ``solve_siwave`` featuring a call to ``subprocess.run()`` has been introduced to the file ``src/pyedb/generic/process.py`` in #1546. 
This occurrence of ``subprocess.run()`` has unfortunately been missed when working on #1530.

Here it gets reviewed and handled following the same principles as those applied in #1530 (listed in the PR description and discussed in comments): 
* This call to ``subprocess.run()`` was already contained in a ``try / except`` structure and the argument ``check=True`` was passed, allowing for a properly implemented exception handling with a ``RuntimeError`` being raised in case an error is caught,
* The usual warning has been inserted in the docstring of the method ``solve_siwave``,
* The necessary ``# nosec`` flags have been added where needed, 
* The variable name ``command`` is appropriately used to name the command being passed to that instance of ``subprocess.run()``,
* The command is defined as a list.