### PR TITLE
CHORE: Adding ``SECURITY.md`` file

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,6 @@
 Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
 SPDX-License-Identifier: MIT
 
-
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+<!--
+Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+SPDX-License-Identifier: MIT
+
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+
+# Security Policy
+
+## Reporting a vulnerability
+
+> [!CAUTION]
+> Do not use GitHub issues to report any security vulnerabilities.
+
+If you detect a vulnerability, contact the [PyAnsys Core team](mailto:pyansys.core@ansys.com),
+mentioning the repository and the details of your finding. The team will address it as soon as possible.
+
+Provide the PyAnsys Core team with this information:
+
+- Any specific configuration settings needed to reproduce the problem
+- Step-by-step guidance to reproduce the problem
+- The exact location of the problematic source code, including tag, branch, commit, or a direct URL
+- The potential consequences of the vulnerability, along with a description of how an attacker could take advantage of the issue


### PR DESCRIPTION
This PR is adding a ``SECURITY.md`` file based on the model provided [here](https://github.com/ansys-internal/pyansys-maintenance-automation/tree/main/scripts/file_references).
This file is placed at the root of the repository and complemented by the license header used elsewhere in the project.

Close #1316.