### PR TITLE
CI: Add vulnerability check

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -37,6 +37,17 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           use-upper-case: true
 
+  vulnerabilities:
+    name: Vulnerabilities
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ansys/actions/check-vulnerabilities@123a1f17d71f117e0ba29c53d6a0f602e0d8d902 # v10.1.3
+        with:
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+          python-package-name: ${{ env.PACKAGE_NAME }}
+          token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
+          dev-mode: ${{ github.ref != 'refs/heads/main' }}
+
   doc-style:
     name: Documentation style check
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR is introducing the ``ansys/actions/check-vulnerabilities`` action in the workflow file ``.github/workflows/ci_cd.yml`` and consequently in the CI of ``pyedb`` as requested in #1315.
More information about this action and its purpose can be read from [here](https://actions.docs.ansys.com/version/stable/vulnerability-actions/).

The parameters for the action, as well as its position inside the workflow, are defined based on the current implementation for this check in other PyAnsys projects (such as for instance ``pyaedt``, ``pyspeos`` or ``pyansys-geometry``). 
In particular, no ``extra-targets`` are passed as argument to the action, since ``pyedb`` does not make use of the ``[all]`` target in its ``pyproject.toml`` file. Furthermore, in the case of ``pyedb``, no other workflow job is considered relevant to be declared a prerequisite for the newly introduced action.
The latest release ``v10.1.3`` of ``ansys/actions`` is used.

Close #1315.