### PR TITLE
REFACTOR: remove unused method to retrieve reference primitive from terminal

### DIFF
--- a/doc/changelog.d/1910.miscellaneous.md
+++ b/doc/changelog.d/1910.miscellaneous.md
@@ -1,0 +1,1 @@
+Remove unused method to retrieve reference primitive from terminal

--- a/src/pyedb/grpc/database/terminal/terminal.py
+++ b/src/pyedb/grpc/database/terminal/terminal.py
@@ -387,7 +387,13 @@ class Terminal(ConnObj):
                 if edge_type == CoreEdgeType.PADSTACK:
                     self._reference_object = self.get_pad_edge_terminal_reference_pin()
                 else:
-                    self._reference_object = self.get_edge_terminal_reference_primitive()
+                    if self.core.edges:
+                        if hasattr(self.core.edges[0], "primitive"):
+                            self._reference_object = Primitive(self._pedb, self.core.edges[0].primitive)
+                        else:
+                            self._reference_object = None
+                    else:
+                        self._reference_object = None
             elif self.terminal_type == "pin_group":
                 self._reference_object = self.get_pin_group_terminal_reference_pin()
             elif self.terminal_type == "point":
@@ -473,20 +479,14 @@ class Terminal(ConnObj):
         """Check and return a primitive instance that serves Edge ports,
         wave-ports and coupled-edge ports that are directly connected to primitives.
 
-        Returns
-        -------
-        :class:`Primitive <pyedb.grpc.database.primitive.primitive.Primitive>`
+        .. deprecated:: 0.70.0
+            The `get_edge_terminal_reference_primitive` method is deprecated and not used anymore.
+            Please use `edb.ports["your_port_name"].reference_object` instead if it exists.
         """
-
-        ref_layer = self.reference_layer
-        edges = self.core.edges
-        _, _, point_data = edges[0].get_parameters()
-        layer_name = ref_layer.name
-        for primitive in self._pedb.layout.primitives:
-            if primitive.layer.name == layer_name:
-                if primitive.polygon_data.point_in_polygon(point_data):
-                    return (primitive, self._pedb)
-        return None  # pragma: no cover
+        raise (
+            "get_edge_terminal_reference_primitive is deprecated and not used anymore. "
+            'Please use edb.ports["your_port_name"].reference_object instead if it exists.'
+        )
 
     def get_point_terminal_reference_primitive(self) -> Primitive:
         """

--- a/src/pyedb/grpc/edb.py
+++ b/src/pyedb/grpc/edb.py
@@ -591,7 +591,7 @@ class Edb(EdbInit):
             elif isinstance(t, PadstackInstanceTerminal):
                 ports[t.name] = CoaxPort(self, t.core)
             elif isinstance(t, EdgeTerminal):
-                if getattr(t, "is_wave_port", False):
+                if getattr(t, "is_wave_port", True):
                     ports[t.name] = WavePort(self, t.core)
                 else:
                     ports[t.name] = EdgeTerminal(self, t.core)

--- a/tests/system/test_edb.py
+++ b/tests/system/test_edb.py
@@ -313,6 +313,7 @@ class TestClass(BaseTestClass):
                 terminal_point=port_location,
                 reference_point=ref_location,
             )
+            assert list(edb.ports.values())[-1].reference_object is None
         else:
             # method already deprecated in grpc.
             assert edb.excitation_manager.create_edge_port_on_polygon(
@@ -430,6 +431,8 @@ class TestClass(BaseTestClass):
             assert edb.excitation_manager.create_edge_port_horizontal(
                 prim_1_id, ["-60mm", "-4mm"], prim_2_id, ["-59mm", "-4mm"], "port_hori", 30, "Lower"
             )
+            assert edb.ports["port_hori"].reference_terminal.reference_object is None
+            assert edb.ports["port_hori"].reference_object is None
         else:
             # This method is also available at same location in grpc but is deprecated.
             assert edb.excitation_manager.create_edge_port_horizontal(


### PR DESCRIPTION
This PR is removing unused method to retrieve reference primitive from terminal and tries instead using pyedb-core api to get it when available. The removed code was not working. Instead raising an error message telling what to use, as it is not a deprecation but rather another approach. In any case the previous one could not work.