### PR TITLE
FEAT: grpc in memory 

### DIFF
--- a/doc/changelog.d/1958.added.md
+++ b/doc/changelog.d/1958.added.md
@@ -1,0 +1,1 @@
+Grpc in memory

--- a/src/pyedb/generic/design_types.py
+++ b/src/pyedb/generic/design_types.py
@@ -43,7 +43,7 @@ def Edb(*, grpc: Literal[False] = False, **kwargs) -> "EdbDotnet": ...
 
 
 @overload
-def Edb(*, grpc: bool, **kwargs) -> "EdbGrpc" | "EdbDotnet": ...
+def Edb(*, grpc: bool, **kwargs) -> "EdbGrpc | EdbDotnet": ...
 
 
 # lazy imports
@@ -62,7 +62,8 @@ def Edb(
     grpc: bool = False,
     control_file: str | None = None,
     layer_filter: str | None = None,
-) -> EdbGrpc | EdbDotnet:
+    in_memory: bool = True,
+) -> EdbGrpc | EdbDotnet | None:
     """Provides the EDB application interface.
 
     This module inherits all objects that belong to EDB.
@@ -101,6 +102,11 @@ def Edb(
         Path to the XML file. The default is ``None``, in which case an attempt is made to find
         the XML file in the same directory as the board file. To succeed, the XML file and board file
         must have the same name. Only the extension differs.
+    in_memory : bool, optional
+        When grpc is set to `True`, this flag enable or not the `in_memory` feature to bypass the network socket.
+        Enabling this option is intended to increase performances when processes are running locally on the same
+        machine. This feature status is Beta and default value is `False`.
+
 
     Returns
     -------
@@ -255,6 +261,7 @@ def Edb(
     """
     settings.is_student_version = student_version
     settings.is_grpc = grpc
+    settings.is_in_memory = in_memory
     if grpc is False and settings.edb_dll_path is not None:
         # Check if the user specified a .dll path
         settings.logger.info(f"Force to use .dll from {settings.edb_dll_path} defined in settings.")
@@ -302,6 +309,7 @@ def Edb(
                 map_file=map_file,
                 technology_file=technology_file,
                 control_file=control_file,
+                in_memory=in_memory,
             )
 
         elif float(settings.specified_version) < 2025.2:

--- a/src/pyedb/generic/design_types.py
+++ b/src/pyedb/generic/design_types.py
@@ -62,7 +62,7 @@ def Edb(
     grpc: bool = False,
     control_file: str | None = None,
     layer_filter: str | None = None,
-    in_memory: bool = False,
+    in_memory: bool = True,
 ) -> EdbGrpc | EdbDotnet | None:
     """Provides the EDB application interface.
 

--- a/src/pyedb/generic/design_types.py
+++ b/src/pyedb/generic/design_types.py
@@ -62,7 +62,7 @@ def Edb(
     grpc: bool = False,
     control_file: str | None = None,
     layer_filter: str | None = None,
-    in_memory: bool = True,
+    in_memory: bool = False,
 ) -> EdbGrpc | EdbDotnet | None:
     """Provides the EDB application interface.
 

--- a/src/pyedb/generic/settings.py
+++ b/src/pyedb/generic/settings.py
@@ -76,6 +76,7 @@ class Settings(object):
         self.log_file = None
         self._aedt_version = None
         self.__is_grpc = False
+        self.__is_in_memory = False
         self.__get_version_information()
         self.__init_logger()
 
@@ -92,6 +93,21 @@ class Settings(object):
     @is_grpc.setter
     def is_grpc(self, value):
         self.__is_grpc = value
+
+    @property
+    def is_in_memory(self):
+        """Whether Edb is launched using memory or not. sed only with gRPC. When `True` by pass connection socket.
+        Designed to be used when client and RPC server are both running locally. Performances are expected to be better.
+
+        Returns
+        -------
+        bool
+        """
+        return self.__is_in_memory
+
+    @is_in_memory.setter
+    def is_in_memory(self, value):
+        self.__is_in_memory = value
 
     @property
     def edb_environment_variables(self):

--- a/src/pyedb/grpc/edb.py
+++ b/src/pyedb/grpc/edb.py
@@ -737,7 +737,7 @@ class Edb(EdbInit):
         n_try = 10
         while not self.db and n_try:
             try:
-                self._create(self.edbpath, restart_rpc_server=restart_rpc_server)
+                self._create(self.edbpath, restart_rpc_server=restart_rpc_server, in_memory=self.in_memory)
                 n_try -= 1
             except Exception as e:
                 self.logger.error(e.args[0])

--- a/src/pyedb/grpc/edb.py
+++ b/src/pyedb/grpc/edb.py
@@ -223,10 +223,12 @@ class Edb(EdbInit):
         technology_file: str = None,
         layer_filter: str = None,
         restart_rpc_server=False,
+        in_memory: bool = False,
     ):
         edbversion = get_string_version(version)
         self._clean_variables()
-        EdbInit.__init__(self, edbversion=version)
+        EdbInit.__init__(self, version=version, in_memory=in_memory)
+        self.in_memory = in_memory
         self.standalone = True
         self.oproject = oproject
         self._main = sys.modules["__main__"]
@@ -319,13 +321,13 @@ class Edb(EdbInit):
                 raise AttributeError("Translation was unsuccessful")
         elif edbpath.endswith("edb.def"):
             self.edbpath = os.path.dirname(edbpath)
-            self.open(restart_rpc_server=restart_rpc_server)
+            self.open(restart_rpc_server=restart_rpc_server, in_memory=self.in_memory)
         elif not os.path.exists(os.path.join(self.edbpath, "edb.def")):
             self.create(restart_rpc_server=restart_rpc_server)
             self.logger.info("EDB %s created correctly.", self.edbpath)
         elif ".aedb" in edbpath:
             self.edbpath = edbpath
-            self.open(restart_rpc_server=restart_rpc_server)
+            self.open(restart_rpc_server=restart_rpc_server, in_memory=self.in_memory)
         if self.active_cell:
             self.logger.info("EDB initialized.")
         else:
@@ -673,7 +675,7 @@ class Edb(EdbInit):
         ]
         return {ter.name: ter for ter in terms}
 
-    def open(self, restart_rpc_server=False) -> bool:
+    def open(self, restart_rpc_server: bool = False, in_memory: bool = False) -> bool:
         """Open EDB database.
 
         Returns
@@ -694,6 +696,7 @@ class Edb(EdbInit):
                     self.edbpath,
                     self.isreadonly,
                     restart_rpc_server=restart_rpc_server,
+                    in_memory=in_memory,
                 )
                 n_try -= 1
             except Exception as e:
@@ -907,7 +910,7 @@ class Edb(EdbInit):
             self.logger.info("Translation successfully completed")
         self.edbpath = os.path.join(working_dir, aedb_name)
         # open_edb is deprecated; use open() here to silence deprecation warnings
-        return self.open()
+        return self.open(in_memory=self.in_memory)
 
     def import_vlctech_stackup(
         self,
@@ -962,7 +965,7 @@ class Edb(EdbInit):
         else:
             self.logger.info("edb successfully created.")
         self.edbpath = os.path.join(working_dir, "vlctech.aedb")
-        self.open()
+        self.open(in_memory=self.in_memory)
         return self.edbpath
 
     def export_to_ipc2581(self, edbpath="", anstranslator_full_path="", ipc_path=None) -> str:
@@ -1612,7 +1615,7 @@ class Edb(EdbInit):
                 raise RuntimeError("An error occurred while converting file") from e
             temp_input_gds = input_gds.split(".gds")[0]
             self.edbpath = temp_input_gds + ".aedb"
-            return self.open()
+            return self.open(in_memory=self.in_memory)
 
     @deprecate_argument_name({"signal_list": "signal_nets", "reference_list": "reference_nets"})
     def cutout(
@@ -2934,7 +2937,7 @@ class Edb(EdbInit):
             self.save()
             self.close()
             self.edbpath = edb_original_path
-            self.open()
+            self.open(in_memory=self.in_memory)
         return parameters
 
     @staticmethod

--- a/src/pyedb/grpc/edb_init.py
+++ b/src/pyedb/grpc/edb_init.py
@@ -82,7 +82,7 @@ class EdbInit(object):
         """Active database object."""
         return self._db
 
-    def _create(self, db_path, port=0, restart_rpc_server=False):
+    def _create(self, db_path, port=0, restart_rpc_server=False, in_memory=False):
         """Create a Database at the specified file location.
 
         Parameters
@@ -100,15 +100,17 @@ class EdbInit(object):
         -------
         Database
         """
-        if not RpcSession.pid:
+        RpcSession.in_memory = in_memory
+        if RpcSession.in_memory and not RpcSession.pid:
             RpcSession.start(
                 edb_version=self.version,
                 port=port,
                 restart_server=restart_rpc_server,
             )
-            if not RpcSession.pid:
+            if not RpcSession.pid and not RpcSession.in_memory:
                 self.logger.error("Failed to start RPC server.")
                 return False
+
         self._db = database.Database.create(db_path)
         return self._db
 

--- a/src/pyedb/grpc/edb_init.py
+++ b/src/pyedb/grpc/edb_init.py
@@ -41,10 +41,10 @@ from pyedb.grpc.rpc_session import RpcSession
 class EdbInit(object):
     """Edb Dot Net Class."""
 
-    def __init__(self, edbversion):
+    def __init__(self, version, in_memory=False, is_linux=False):
         self.logger = settings.logger
         self._db = None
-        self.version = edbversion
+        self.version = version
         self.logger.info("Logger is initialized in EDB.")
         self.logger.info("legacy v%s", __version__)
         self.logger.info("Python version %s", sys.version)
@@ -71,6 +71,7 @@ class EdbInit(object):
         # register signal handlers
         signal.signal(signal.SIGTERM, self._signal_handler)
         signal.signal(signal.SIGINT, self._signal_handler)
+        RpcSession.in_memory = in_memory
 
     @staticmethod
     def _signal_handler(signum=None, frame=None):
@@ -111,7 +112,7 @@ class EdbInit(object):
         self._db = database.Database.create(db_path)
         return self._db
 
-    def _open(self, db_path, read_only, port=0, restart_rpc_server=False):
+    def _open(self, db_path, read_only, port=0, restart_rpc_server=False, in_memory=False):
         """Open an existing Database at the specified file location.
 
         Parameters
@@ -132,13 +133,14 @@ class EdbInit(object):
         """
         if restart_rpc_server:
             RpcSession.pid = 0
+        RpcSession.in_memory = in_memory
         if not RpcSession.pid:
             RpcSession.start(
                 edb_version=self.version,
                 port=port,
                 restart_server=restart_rpc_server,
             )
-            if not RpcSession.pid:
+            if not RpcSession.pid and not RpcSession.in_memory:
                 self.logger.error("Failed to start RPC server.")
                 return False
         self._db = database.Database.open(db_path, read_only)
@@ -197,7 +199,7 @@ class EdbInit(object):
         """
         self._db.close()
         self._db = None
-        if terminate_rpc_session:
+        if terminate_rpc_session and not RpcSession.in_memory:
             RpcSession.rpc_session.disconnect()
             RpcSession.pid = 0
         self._clean_variables()

--- a/src/pyedb/grpc/rpc_session.py
+++ b/src/pyedb/grpc/rpc_session.py
@@ -26,6 +26,11 @@ import sys
 import time
 
 from ansys.edb.core.session import launch_session
+
+try:
+    from ansys.edb.core.session import launch_local_session
+except ImportError:
+    print("local session is development feature")
 from ansys.edb.core.utility.io_manager import (
     IOMangementType,
     end_managing,
@@ -48,6 +53,7 @@ class RpcSession:
     rpc_session = None
     base_path = None
     port = 10000
+    in_memory = False
 
     @staticmethod
     def start(edb_version, port=0, restart_server=False):
@@ -105,19 +111,28 @@ class RpcSession:
         os.environ["PATH"] = "{};{}".format(os.environ["PATH"], RpcSession.base_path)
 
         if RpcSession.pid:
-            if restart_server:
+            if restart_server and not RpcSession.in_memory:
                 settings.logger.logger.info("Restarting RPC server")
                 RpcSession.kill()
                 RpcSession.__start_rpc_server()
-            else:
+            elif not RpcSession.in_memory:
                 settings.logger.info(f"Server already running on port {RpcSession.port}")
+
+            if restart_server and RpcSession.in_memory:
+                settings.logger.logger.info("Restarting RPC in-memory server")
+                RpcSession.kill()
+                RpcSession.__start_local_rpc()
         else:
-            RpcSession.__start_rpc_server()
-            if RpcSession.rpc_session:
-                RpcSession.server_pid = RpcSession.rpc_session.local_server_proc.pid
-                settings.logger.info(f"Grpc session started: pid={RpcSession.server_pid}")
+            if not RpcSession.in_memory:
+                RpcSession.__start_rpc_server()
+                if RpcSession.rpc_session:
+                    RpcSession.server_pid = RpcSession.rpc_session.local_server_proc.pid
+                    settings.logger.info(f"Grpc session started: pid={RpcSession.server_pid}")
+                else:
+                    settings.logger.error("Failed to start EDB_RPC_server process")
             else:
-                settings.logger.error("Failed to start EDB_RPC_server process")
+                RpcSession.__start_local_rpc()
+                settings.logger.info("Grpc session started in local mode (fast)")
 
     @staticmethod
     def __get_process_id():
@@ -136,6 +151,10 @@ class RpcSession:
         if RpcSession.rpc_session:
             RpcSession.pid = RpcSession.rpc_session.local_server_proc.pid
             settings.logger.logger.info("Grpc session started")
+
+    @staticmethod
+    def __start_local_rpc():
+        RpcSession.rpc_session = launch_local_session(RpcSession.base_path)
 
     @staticmethod
     def kill():

--- a/src/pyedb/grpc/rpc_session.py
+++ b/src/pyedb/grpc/rpc_session.py
@@ -117,11 +117,6 @@ class RpcSession:
                 RpcSession.__start_rpc_server()
             elif not RpcSession.in_memory:
                 settings.logger.info(f"Server already running on port {RpcSession.port}")
-
-            if restart_server and RpcSession.in_memory:
-                settings.logger.logger.info("Restarting RPC in-memory server")
-                RpcSession.kill()
-                RpcSession.__start_local_rpc()
         else:
             if not RpcSession.in_memory:
                 RpcSession.__start_rpc_server()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,10 +45,12 @@ example_models_path = Path(__file__).parent / "example_models"
 # Initialize default desktop configuration
 
 use_grpc = os.getenv("USE_GRPC") in {"1", True}
+use_in_memory = os.getenv("IN_MEMORY") in {"1", True}
 
 config = {
     "desktopVersion": "2025.2",
     "use_grpc": use_grpc,
+    "in_memory": use_in_memory,
 }
 
 # Check for the local config file, override defaults if found
@@ -63,6 +65,7 @@ if os.path.exists(local_config_file):
 
 desktop_version = config["desktopVersion"]
 GRPC = config["use_grpc"]
+IN_MEMORY = config["in_memory"]
 
 test_subfolder = "TEDB"
 test_project_name = "ANSYS-HSD_V1"
@@ -107,8 +110,9 @@ def local_scratch(init_scratch):
 
 
 class EdbExamples:
-    def __init__(self, local_scratch: "Scratch", grpc=False):
+    def __init__(self, local_scratch: "Scratch", grpc=False, in_memory=False):
         self.grpc = grpc
+        self.in_memory = in_memory
         self.local_scratch = local_scratch
         self.example_models_path = example_models_path
         self.test_folder = ""
@@ -138,7 +142,7 @@ class EdbExamples:
         target_file = self.copy_test_files_into_local_folder("si_verse/ANSYS-HSD_V1.aedb")[0]
         if edbapp:
             version = desktop_version if version is None else version
-            return Edb(edbpath=target_file, version=version, grpc=self.grpc)
+            return Edb(edbpath=target_file, version=version, grpc=self.grpc, in_memory=self.in_memory)
         else:
             return target_file
 
@@ -146,7 +150,7 @@ class EdbExamples:
         target_file = self.copy_test_files_into_local_folder("wirebond_projects/test_wb_jedec4.aedb")[0]
         if edbapp:
             version = desktop_version if version is None else version
-            return Edb(edbpath=target_file, version=version, grpc=self.grpc)
+            return Edb(edbpath=target_file, version=version, grpc=self.grpc, in_memory=self.in_memory)
         else:
             return target_file
 
@@ -154,7 +158,7 @@ class EdbExamples:
         target_file = self.copy_test_files_into_local_folder("si_verse/ANSYS_SVP_V1_1_SFP.aedb")[0]
         if edbapp:
             version = desktop_version if version is None else version
-            return Edb(target_file, version=version, grpc=self.grpc)
+            return Edb(edbpath=target_file, version=version, grpc=self.grpc, in_memory=self.in_memory)
         else:
             return target_file
 
@@ -163,45 +167,45 @@ class EdbExamples:
         target_file = self.copy_test_files_into_local_folder("TEDB/example_package.aedb")[0]
         if edbapp:
             version = desktop_version if version is None else version
-            return Edb(target_file, version=version, grpc=self.grpc)
+            return Edb(edbpath=target_file, version=version, grpc=self.grpc, in_memory=self.in_memory)
         else:
             return target_file
 
     def create_empty_edb(self):
         aedb = os.path.join(self.test_folder, f"new_layout_{generate_random_string(6)}.aedb")
-        edbapp = Edb(aedb, version=desktop_version, grpc=self.grpc)
-        edbapp.save_edb()
+        edbapp = Edb(edbpath=aedb, version=desktop_version, grpc=self.grpc, in_memory=self.in_memory)
+        edbapp.save()
         return edbapp
 
     def get_multizone_pcb(self, version=None):
         target_file = self.copy_test_files_into_local_folder("multi_zone_project.aedb")[0]
         version = desktop_version if version is None else version
-        return Edb(target_file, version=version, grpc=self.grpc)
+        return Edb(edbpath=target_file, version=version, grpc=self.grpc, in_memory=self.in_memory)
 
     def get_unit_cell(self, version=None):
         target_file = self.copy_test_files_into_local_folder("TEDB/unitcell.aedb")[0]
         version = desktop_version if version is None else version
-        return Edb(target_file, version=version, grpc=self.grpc)
+        return Edb(edbpath=target_file, version=version, grpc=self.grpc, in_memory=self.in_memory)
 
     def get_no_ref_pins_component(self, version=None):
         target_file = self.copy_test_files_into_local_folder("TEDB/component_no_ref_pins.aedb")[0]
         version = desktop_version if version is None else version
-        return Edb(target_file, version=version, grpc=self.grpc)
+        return Edb(edbpath=target_file, version=version, grpc=self.grpc, in_memory=self.in_memory)
 
     def get_si_board(self, edbapp=True, additional_files_folders="", version=None):
         target_file = self.copy_test_files_into_local_folder("si_board/si_board.aedb")[0]
         if edbapp:
             version = desktop_version if version is None else version
-            return Edb(target_file, version=version, grpc=self.grpc)
+            return Edb(edbpath=target_file, version=version, grpc=self.grpc, in_memory=self.in_memory)
         else:
             return target_file
 
     def load_edb(self, edb_path, **kwargs):
-        return Edb(edbpath=edb_path, edbversion=desktop_version, grpc=self.grpc, **kwargs)
+        return Edb(edbpath=edb_path, edbversion=desktop_version, grpc=self.grpc, in_memory=self.in_memory, **kwargs)
 
     def load_dxf_edb(self):
         aedb = self.copy_test_files_into_local_folder("dxf_swap/starting_edb/starting_edb.aedb")[0]
-        return Edb(edbpath=aedb, version=desktop_version, grpc=self.grpc)
+        return Edb(edbpath=aedb, version=desktop_version, grpc=self.grpc, in_memory=self.in_memory)
 
     def get_log_file_example(self):
         return os.path.join(self.example_models_path, "test.log")
@@ -212,7 +216,7 @@ class EdbExamples:
 
 @pytest.fixture(scope="class", autouse=True)
 def get_edb_examples(local_scratch):
-    return EdbExamples(local_scratch, GRPC)
+    return EdbExamples(local_scratch, GRPC, IN_MEMORY)
 
 
 class Scratch:


### PR DESCRIPTION
This PR is adding the feature available soon enabling fast grpc with by passing network socket. 
A new flag is introduced when instantiating Edb class. The flag in_memory is introduced and works with grpc=True.
Default value is in_memory=False so pyedb keeps working as usual. When feature is ready the flag will be turned to True by default as same time as grpc.

closes #1959 