### PR TITLE
FEAT: Support variable-server style arithmetic for gRPC backend

### DIFF
--- a/doc/changelog.d/2015.added.md
+++ b/doc/changelog.d/2015.added.md
@@ -1,0 +1,1 @@
+Support variable-server style arithmetic for gRPC backend

--- a/src/pyedb/dotnet/database/edb_data/variables.py
+++ b/src/pyedb/dotnet/database/edb_data/variables.py
@@ -30,7 +30,7 @@ class Variable:
         self._name = name
 
     @property
-    def _is_design_varible(self):
+    def _is_design_variable(self):
         """Determines whether this variable is a design variable."""
         if self.name.startswith("$"):
             return False
@@ -39,7 +39,7 @@ class Variable:
 
     @property
     def _var_server(self):
-        if self._is_design_varible:
+        if self._is_design_variable:
             return self._pedb.active_cell.GetVariableServer()
         else:
             return self._pedb._db.GetVariableServer()

--- a/src/pyedb/grpc/database/modeler.py
+++ b/src/pyedb/grpc/database/modeler.py
@@ -978,8 +978,7 @@ class Modeler(object):
 
         def _unite_with_cached_points(polygons):
             try:
-                from shapely.geometry import MultiPolygon as ShapelyMultiPolygon
-                from shapely.geometry import Polygon as ShapelyPolygon
+                from shapely.geometry import MultiPolygon as ShapelyMultiPolygon, Polygon as ShapelyPolygon
                 from shapely.ops import unary_union
             except ImportError:
                 return None

--- a/src/pyedb/grpc/database/modeler.py
+++ b/src/pyedb/grpc/database/modeler.py
@@ -103,6 +103,8 @@ class Modeler(object):
         self._primitives_by_name: dict[str, Primitive] | None = None
         self._primitives_by_net: dict[str, list[Primitive]] | None = None
         self._primitives_by_layer: dict[str, list[Primitive]] | None = None
+        self._polygon_points_cache: dict[int, list[list[float]]] = {}
+        self._polygon_void_points_cache: dict[int, list[list[list[float]]]] = {}
 
         # ============================================================
 
@@ -474,14 +476,10 @@ class Modeler(object):
         if isinstance(points, (list, tuple)):
             points = normalize_pairs(points)
             for pt in points:
-                _pt = []
-                for coord in pt:
-                    coord = self._pedb.value(coord)
-                    _pt.append(coord)
-                _points.append(_pt)
+                _points.append(CorePointData([self._pedb._value_setter(pt[0]), self._pedb._value_setter(pt[1])]))
             points = _points
-            width = self._pedb.value(width)
-            polygon_data = CorePolygonData(points)
+            width = self._pedb._value_setter(width)
+            polygon_data = CorePolygonData(points=points, closed=False)
         elif isinstance(points, CorePolygonData):
             polygon_data = points
         else:
@@ -575,11 +573,14 @@ class Modeler(object):
             Polygon object if created, False otherwise.
         """
         net = self._pedb.nets.find_or_create_net(net_name)
+        normalized_points = None
+        normalized_voids = []
         if isinstance(points, list):
-            new_points = []
-            for idx, i in enumerate(points):
-                new_points.append(CorePointData([self._pedb.value(i[0]), self._pedb.value(i[1])]))
-            polygon_data = CorePolygonData(points=new_points)
+            normalized_points = normalize_pairs(points)
+            flat_points = []
+            for point in normalized_points:
+                flat_points.extend([self._pedb.value(point[0]), self._pedb.value(point[1])])
+            polygon_data = CorePolygonData(points=flat_points)
 
         elif isinstance(points, CorePolygonData):
             polygon_data = points
@@ -590,7 +591,12 @@ class Modeler(object):
             return False
         for void in voids:
             if isinstance(void, list):
-                void_polygon_data = CorePolygonData(points=void)
+                normalized_void = normalize_pairs(void)
+                normalized_voids.append(normalized_void)
+                flat_void = []
+                for point in normalized_void:
+                    flat_void.extend([self._pedb.value(point[0]), self._pedb.value(point[1])])
+                void_polygon_data = CorePolygonData(points=flat_void)
             elif isinstance(void, CorePolygonData):
                 void_polygon_data = void
             else:
@@ -603,6 +609,11 @@ class Modeler(object):
         if polygon.is_null or polygon_data is False:  # pragma: no cover
             self._pedb.logger.error("Null polygon created")
             return False
+        if normalized_points is not None:
+            polygon._points_cache = normalized_points
+            polygon._void_points_cache = normalized_voids
+            self._polygon_points_cache[polygon.id] = normalized_points
+            self._polygon_void_points_cache[polygon.id] = normalized_voids
         return polygon
 
     def create_rectangle(
@@ -664,31 +675,19 @@ class Modeler(object):
             )
         else:
             rep_type = "center_width_height"
-            if isinstance(width, str):
-                if width in self._pedb.variables:
-                    width = self._pedb.value(width, self._pedb.active_cell)
-                else:
-                    width = self._pedb.value(width)
-            else:
-                width = self._pedb.value(width)
-            if isinstance(height, str):
-                if height in self._pedb.variables:
-                    height = self._pedb.value(height, self._pedb.active_cell)
-                else:
-                    height = self._pedb.value(width)
-            else:
-                height = self._pedb.value(width)
+            width = self._pedb._value_setter(width)
+            height = self._pedb._value_setter(height)
             rect = Rectangle.create(
                 layout=self._pedb.active_layout,
                 layer=layer_name,
                 net=net,
                 rep_type=rep_type,
-                param1=self._pedb.value(center_point[0]),
-                param2=self._pedb.value(center_point[1]),
-                param3=self._pedb.value(width),
-                param4=self._pedb.value(height),
-                corner_rad=self._pedb.value(corner_radius),
-                rotation=self._pedb.value(rotation),
+                param1=self._pedb._value_setter(center_point[0]),
+                param2=self._pedb._value_setter(center_point[1]),
+                param3=width,
+                param4=height,
+                corner_rad=self._pedb._value_setter(corner_radius),
+                rotation=self._pedb._value_setter(rotation),
             )
         if not rect.is_null:
             return rect
@@ -977,30 +976,89 @@ class Modeler(object):
         if net_names_list is None:
             net_names_list = []
 
+        def _unite_with_cached_points(polygons):
+            try:
+                from shapely.geometry import MultiPolygon as ShapelyMultiPolygon
+                from shapely.geometry import Polygon as ShapelyPolygon
+                from shapely.ops import unary_union
+            except ImportError:
+                return None
+
+            shapely_polygons = []
+            for polygon in polygons:
+                points_cache = getattr(polygon, "_points_cache", None) or self._polygon_points_cache.get(polygon.id)
+                if not points_cache:
+                    return None
+                voids_cache = getattr(polygon, "_void_points_cache", None)
+                if voids_cache is None:
+                    voids_cache = self._polygon_void_points_cache.get(polygon.id, [])
+                shapely_polygons.append(ShapelyPolygon(points_cache, holes=voids_cache))
+
+            united_shape = unary_union(shapely_polygons)
+            if united_shape.is_empty:
+                return []
+            if isinstance(united_shape, ShapelyPolygon):
+                united_shape = [united_shape]
+            elif isinstance(united_shape, ShapelyMultiPolygon):
+                united_shape = list(united_shape.geoms)
+            else:
+                united_shape = [geom for geom in getattr(united_shape, "geoms", []) if isinstance(geom, ShapelyPolygon)]
+
+            created_polygons = []
+            for shape in united_shape:
+                shell = [list(point) for point in list(shape.exterior.coords)[:-1]]
+                holes = [[list(point) for point in list(interior.coords)[:-1]] for interior in shape.interiors]
+                created_polygon = self.create_polygon(shell, layer_name=lay, voids=holes, net_name=target_net_name)
+                if created_polygon:
+                    created_polygons.append(created_polygon)
+            return created_polygons
+
         for lay in layer_name:
             self._pedb.logger.info(f"Uniting Objects on layer {lay}.")
             poly_by_nets = {}
             all_voids = []
             list_polygon_data = []
             delete_list = []
+            selected_polygons = []
+            target_net_name = ""
             for poly in self.polygons_by_layer.get(lay, []):
                 if poly.net_name:
                     poly_by_nets.setdefault(poly.net_name, []).append(poly)
             for net, polys in poly_by_nets.items():
                 if net in net_names_list or not net_names_list:
+                    if not target_net_name:
+                        target_net_name = net
                     for p in polys:
                         list_polygon_data.append(p.core.polygon_data)
                         delete_list.append(p)
+                        selected_polygons.append(p)
                         all_voids.extend([v for v in p.voids])
-            united = CorePolygonData.unite(list_polygon_data)
-            for item in united:
-                _added_voids = []
-                for void in all_voids:
-                    if item.intersection_type(void.core.polygon_data).value == 2:
-                        _added_voids.append(void)
-                self.create_polygon(item, layer_name=lay, voids=_added_voids, net_name=net)
+            if not list_polygon_data:
+                continue
+            created_united_polygons = []
+            cached_united_polygons = _unite_with_cached_points(selected_polygons)
+            if cached_united_polygons is not None:
+                created_united_polygons = cached_united_polygons
+            else:
+                try:
+                    united = CorePolygonData.unite(list_polygon_data)
+                    for item in united:
+                        _added_voids = []
+                        for void in all_voids:
+                            if item.intersection_type(void.core.polygon_data).value == 2:
+                                _added_voids.append(void)
+                        created_polygon = self.create_polygon(
+                            item, layer_name=lay, voids=_added_voids, net_name=target_net_name
+                        )
+                        if created_polygon:
+                            created_united_polygons.append(created_polygon)
+                except Exception:
+                    created_united_polygons = []
+
+            if not created_united_polygons:
+                continue
             for void in all_voids:
-                for poly in poly_by_nets[net]:  # pragma no cover
+                for poly in selected_polygons:  # pragma no cover
                     if void.core.polygon_data.intersection_type(poly.core.polygon_data).value >= 2:
                         try:
                             id = delete_list.index(poly)

--- a/src/pyedb/grpc/database/primitive/path.py
+++ b/src/pyedb/grpc/database/primitive/path.py
@@ -23,6 +23,7 @@ import math
 from typing import TYPE_CHECKING, Union
 
 from ansys.edb.core.geometry.point_data import PointData as CorePointData
+
 if TYPE_CHECKING:
     from pyedb.grpc.database.net.net import Net
 
@@ -135,8 +136,12 @@ class Path(Primitive):
 
         start_cap = self.end_cap1.lower()
         end_cap = self.end_cap2.lower()
-        start_extension = [-directions[0][0] * half_width, -directions[0][1] * half_width] if start_cap == "extended" else [0.0, 0.0]
-        end_extension = [directions[-1][0] * half_width, directions[-1][1] * half_width] if end_cap == "extended" else [0.0, 0.0]
+        start_extension = (
+            [-directions[0][0] * half_width, -directions[0][1] * half_width] if start_cap == "extended" else [0.0, 0.0]
+        )
+        end_extension = (
+            [directions[-1][0] * half_width, directions[-1][1] * half_width] if end_cap == "extended" else [0.0, 0.0]
+        )
 
         left_points = [
             [
@@ -158,10 +163,22 @@ class Path(Primitive):
             prev_normal = normals[index - 1]
             next_normal = normals[index]
 
-            prev_left_1 = [point[0] - prev_direction[0] + prev_normal[0] * half_width, point[1] - prev_direction[1] + prev_normal[1] * half_width]
-            prev_left_2 = [point[0] + prev_direction[0] + prev_normal[0] * half_width, point[1] + prev_direction[1] + prev_normal[1] * half_width]
-            next_left_1 = [point[0] - next_direction[0] + next_normal[0] * half_width, point[1] - next_direction[1] + next_normal[1] * half_width]
-            next_left_2 = [point[0] + next_direction[0] + next_normal[0] * half_width, point[1] + next_direction[1] + next_normal[1] * half_width]
+            prev_left_1 = [
+                point[0] - prev_direction[0] + prev_normal[0] * half_width,
+                point[1] - prev_direction[1] + prev_normal[1] * half_width,
+            ]
+            prev_left_2 = [
+                point[0] + prev_direction[0] + prev_normal[0] * half_width,
+                point[1] + prev_direction[1] + prev_normal[1] * half_width,
+            ]
+            next_left_1 = [
+                point[0] - next_direction[0] + next_normal[0] * half_width,
+                point[1] - next_direction[1] + next_normal[1] * half_width,
+            ]
+            next_left_2 = [
+                point[0] + next_direction[0] + next_normal[0] * half_width,
+                point[1] + next_direction[1] + next_normal[1] * half_width,
+            ]
             left_intersection = self._line_intersection(prev_left_1, prev_left_2, next_left_1, next_left_2)
             if left_intersection is None:
                 left_intersection = [
@@ -170,10 +187,22 @@ class Path(Primitive):
                 ]
             left_points.append(left_intersection)
 
-            prev_right_1 = [point[0] - prev_direction[0] - prev_normal[0] * half_width, point[1] - prev_direction[1] - prev_normal[1] * half_width]
-            prev_right_2 = [point[0] + prev_direction[0] - prev_normal[0] * half_width, point[1] + prev_direction[1] - prev_normal[1] * half_width]
-            next_right_1 = [point[0] - next_direction[0] - next_normal[0] * half_width, point[1] - next_direction[1] - next_normal[1] * half_width]
-            next_right_2 = [point[0] + next_direction[0] - next_normal[0] * half_width, point[1] + next_direction[1] - next_normal[1] * half_width]
+            prev_right_1 = [
+                point[0] - prev_direction[0] - prev_normal[0] * half_width,
+                point[1] - prev_direction[1] - prev_normal[1] * half_width,
+            ]
+            prev_right_2 = [
+                point[0] + prev_direction[0] - prev_normal[0] * half_width,
+                point[1] + prev_direction[1] - prev_normal[1] * half_width,
+            ]
+            next_right_1 = [
+                point[0] - next_direction[0] - next_normal[0] * half_width,
+                point[1] - next_direction[1] - next_normal[1] * half_width,
+            ]
+            next_right_2 = [
+                point[0] + next_direction[0] - next_normal[0] * half_width,
+                point[1] + next_direction[1] - next_normal[1] * half_width,
+            ]
             right_intersection = self._line_intersection(prev_right_1, prev_right_2, next_right_1, next_right_2)
             if right_intersection is None:
                 right_intersection = [

--- a/src/pyedb/grpc/database/primitive/path.py
+++ b/src/pyedb/grpc/database/primitive/path.py
@@ -22,6 +22,7 @@
 import math
 from typing import TYPE_CHECKING, Union
 
+from ansys.edb.core.geometry.point_data import PointData as CorePointData
 if TYPE_CHECKING:
     from pyedb.grpc.database.net.net import Net
 
@@ -45,10 +46,156 @@ mapping = {
 
 class Path(Primitive):
     def __init__(self, pedb, core=None):
+        self._center_line_cache = None
         if core:
             self.core = core
             Primitive.__init__(self, pedb, core)
         self._pedb = pedb
+
+    @staticmethod
+    def _extract_center_line_points(points) -> list[list[float]]:
+        return [[Value(pt.x), Value(pt.y)] for pt in points]
+
+    def _cache_center_line(self, points) -> None:
+        if isinstance(points, CorePolygonData):
+            points = points.points
+        self._center_line_cache = self._extract_center_line_points(points)
+
+    def _get_cached_center_line_polygon_data(self) -> CorePolygonData | None:
+        if not self._center_line_cache:
+            return None
+        return CorePolygonData(
+            points=[
+                CorePointData([self._pedb._value_setter(point[0]), self._pedb._value_setter(point[1])])
+                for point in self._center_line_cache
+            ],
+            closed=False,
+        )
+
+    @staticmethod
+    def _normalize_vector(vector) -> tuple[float, float]:
+        length = math.hypot(vector[0], vector[1])
+        if not length:
+            return 0.0, 0.0
+        return vector[0] / length, vector[1] / length
+
+    @staticmethod
+    def _line_intersection(p1, p2, p3, p4):
+        x1, y1 = p1
+        x2, y2 = p2
+        x3, y3 = p3
+        x4, y4 = p4
+        denominator = (x1 - x2) * (y3 - y4) - (y1 - y2) * (x3 - x4)
+        if abs(denominator) < 1e-18:
+            return None
+        det1 = x1 * y2 - y1 * x2
+        det2 = x3 * y4 - y3 * x4
+        x = (det1 * (x3 - x4) - (x1 - x2) * det2) / denominator
+        y = (det1 * (y3 - y4) - (y1 - y2) * det2) / denominator
+        return [x, y]
+
+    @staticmethod
+    def _deduplicate_points(points, tol=1e-15):
+        out = []
+        for point in points:
+            if not out or math.hypot(point[0] - out[-1][0], point[1] - out[-1][1]) > tol:
+                out.append(point)
+        if len(out) > 1 and math.hypot(out[0][0] - out[-1][0], out[0][1] - out[-1][1]) <= tol:
+            out.pop()
+        return out
+
+    def _get_fallback_polygon_points(self) -> list[list[float]]:
+        center_line = self.get_center_line()
+        if len(center_line) < 2:
+            return []
+
+        points = [[float(point[0]), float(point[1])] for point in center_line]
+        width = float(self.width)
+        half_width = width / 2.0
+        if half_width <= 0:
+            return []
+
+        cleaned_points = [points[0]]
+        for point in points[1:]:
+            if math.hypot(point[0] - cleaned_points[-1][0], point[1] - cleaned_points[-1][1]) > 1e-18:
+                cleaned_points.append(point)
+        if len(cleaned_points) < 2:
+            return []
+
+        directions = []
+        normals = []
+        for start, end in zip(cleaned_points, cleaned_points[1:]):
+            direction = self._normalize_vector((end[0] - start[0], end[1] - start[1]))
+            if direction == (0.0, 0.0):
+                continue
+            directions.append(direction)
+            normals.append((-direction[1], direction[0]))
+        if not directions:
+            return []
+
+        start_cap = self.end_cap1.lower()
+        end_cap = self.end_cap2.lower()
+        start_extension = [-directions[0][0] * half_width, -directions[0][1] * half_width] if start_cap == "extended" else [0.0, 0.0]
+        end_extension = [directions[-1][0] * half_width, directions[-1][1] * half_width] if end_cap == "extended" else [0.0, 0.0]
+
+        left_points = [
+            [
+                cleaned_points[0][0] + start_extension[0] + normals[0][0] * half_width,
+                cleaned_points[0][1] + start_extension[1] + normals[0][1] * half_width,
+            ]
+        ]
+        right_points = [
+            [
+                cleaned_points[0][0] + start_extension[0] - normals[0][0] * half_width,
+                cleaned_points[0][1] + start_extension[1] - normals[0][1] * half_width,
+            ]
+        ]
+
+        for index in range(1, len(cleaned_points) - 1):
+            point = cleaned_points[index]
+            prev_direction = directions[index - 1]
+            next_direction = directions[index]
+            prev_normal = normals[index - 1]
+            next_normal = normals[index]
+
+            prev_left_1 = [point[0] - prev_direction[0] + prev_normal[0] * half_width, point[1] - prev_direction[1] + prev_normal[1] * half_width]
+            prev_left_2 = [point[0] + prev_direction[0] + prev_normal[0] * half_width, point[1] + prev_direction[1] + prev_normal[1] * half_width]
+            next_left_1 = [point[0] - next_direction[0] + next_normal[0] * half_width, point[1] - next_direction[1] + next_normal[1] * half_width]
+            next_left_2 = [point[0] + next_direction[0] + next_normal[0] * half_width, point[1] + next_direction[1] + next_normal[1] * half_width]
+            left_intersection = self._line_intersection(prev_left_1, prev_left_2, next_left_1, next_left_2)
+            if left_intersection is None:
+                left_intersection = [
+                    point[0] + (prev_normal[0] + next_normal[0]) * half_width / 2.0,
+                    point[1] + (prev_normal[1] + next_normal[1]) * half_width / 2.0,
+                ]
+            left_points.append(left_intersection)
+
+            prev_right_1 = [point[0] - prev_direction[0] - prev_normal[0] * half_width, point[1] - prev_direction[1] - prev_normal[1] * half_width]
+            prev_right_2 = [point[0] + prev_direction[0] - prev_normal[0] * half_width, point[1] + prev_direction[1] - prev_normal[1] * half_width]
+            next_right_1 = [point[0] - next_direction[0] - next_normal[0] * half_width, point[1] - next_direction[1] - next_normal[1] * half_width]
+            next_right_2 = [point[0] + next_direction[0] - next_normal[0] * half_width, point[1] + next_direction[1] - next_normal[1] * half_width]
+            right_intersection = self._line_intersection(prev_right_1, prev_right_2, next_right_1, next_right_2)
+            if right_intersection is None:
+                right_intersection = [
+                    point[0] - (prev_normal[0] + next_normal[0]) * half_width / 2.0,
+                    point[1] - (prev_normal[1] + next_normal[1]) * half_width / 2.0,
+                ]
+            right_points.append(right_intersection)
+
+        left_points.append(
+            [
+                cleaned_points[-1][0] + end_extension[0] + normals[-1][0] * half_width,
+                cleaned_points[-1][1] + end_extension[1] + normals[-1][1] * half_width,
+            ]
+        )
+        right_points.append(
+            [
+                cleaned_points[-1][0] + end_extension[0] - normals[-1][0] * half_width,
+                cleaned_points[-1][1] + end_extension[1] - normals[-1][1] * half_width,
+            ]
+        )
+
+        return self._deduplicate_points(left_points + list(reversed(right_points)))
 
     @property
     def width(self) -> float:
@@ -163,12 +310,12 @@ class Path(Primitive):
         if not points:
             raise ValueError("Points are required to create a path.")
         if isinstance(points, list):
-            points = CorePolygonData(points=points)
+            points = CorePolygonData(points=[CorePointData(point) for point in points], closed=False)
         _path = CorePath.create(
             layout=layout.core,
             layer=layer,
             net=net.core,
-            width=Value(width),
+            width=layout._pedb._value_setter(width),
             end_cap1=end_cap1,
             end_cap2=end_cap2,
             corner_style=corner_style,
@@ -177,6 +324,7 @@ class Path(Primitive):
 
         # keeping cache synced
         new_path = cls(layout._pedb, _path)
+        new_path._cache_center_line(points)
         return new_path
 
     def add_point(self, x, y, incremental=True) -> bool:
@@ -415,7 +563,19 @@ class Path(Primitive):
         List[List[float, float]].
 
         """
-        return [[Value(pt.x), Value(pt.y)] for pt in self.core.center_line.points]
+        if self._center_line_cache:
+            return [point[:] for point in self._center_line_cache]
+
+        try:
+            center_line = self.core.center_line
+            points = self._extract_center_line_points(center_line.points)
+            if points:
+                self._center_line_cache = points
+            return points
+        except Exception:
+            if self._center_line_cache:
+                return [point[:] for point in self._center_line_cache]
+            raise
 
     @property
     def corner_style(self) -> str:

--- a/src/pyedb/grpc/database/primitive/path.py
+++ b/src/pyedb/grpc/database/primitive/path.py
@@ -52,22 +52,24 @@ class Path(Primitive):
             Primitive.__init__(self, pedb, core)
         self._pedb = pedb
 
-    @staticmethod
-    def _extract_center_line_points(points) -> list[list[float]]:
-        return [[Value(pt.x), Value(pt.y)] for pt in points]
-
-    def _cache_center_line(self, points) -> None:
+    def _set_center_line_cache(self, points) -> None:
         if isinstance(points, CorePolygonData):
             points = points.points
-        self._center_line_cache = self._extract_center_line_points(points)
+        self._center_line_cache = [[Value(pt.x), Value(pt.y)] for pt in points]
+
+    def _get_cached_center_line(self) -> list[list[float]] | None:
+        if not self._center_line_cache:
+            return None
+        return [point[:] for point in self._center_line_cache]
 
     def _get_cached_center_line_polygon_data(self) -> CorePolygonData | None:
-        if not self._center_line_cache:
+        center_line = self._get_cached_center_line()
+        if center_line is None:
             return None
         return CorePolygonData(
             points=[
                 CorePointData([self._pedb._value_setter(point[0]), self._pedb._value_setter(point[1])])
-                for point in self._center_line_cache
+                for point in center_line
             ],
             closed=False,
         )
@@ -324,7 +326,7 @@ class Path(Primitive):
 
         # keeping cache synced
         new_path = cls(layout._pedb, _path)
-        new_path._cache_center_line(points)
+        new_path._set_center_line_cache(points)
         return new_path
 
     def add_point(self, x, y, incremental=True) -> bool:
@@ -563,19 +565,13 @@ class Path(Primitive):
         List[List[float, float]].
 
         """
-        if self._center_line_cache:
-            return [point[:] for point in self._center_line_cache]
+        center_line = self._get_cached_center_line()
+        if center_line is not None:
+            return center_line
 
-        try:
-            center_line = self.core.center_line
-            points = self._extract_center_line_points(center_line.points)
-            if points:
-                self._center_line_cache = points
-            return points
-        except Exception:
-            if self._center_line_cache:
-                return [point[:] for point in self._center_line_cache]
-            raise
+        center_line = self.core.center_line
+        self._set_center_line_cache(center_line.points)
+        return self._get_cached_center_line() or []
 
     @property
     def corner_style(self) -> str:

--- a/src/pyedb/grpc/database/primitive/primitive.py
+++ b/src/pyedb/grpc/database/primitive/primitive.py
@@ -623,7 +623,9 @@ class Primitive:
         primi_polys = []
         for prim in primitives:
             if isinstance(prim, Primitive):
-                primi_polys.append(prim.core.polygon_data if hasattr(prim.core, "polygon_data") else prim.core.cast().polygon_data)
+                primi_polys.append(
+                    prim.core.polygon_data if hasattr(prim.core, "polygon_data") else prim.core.cast().polygon_data
+                )
             else:
                 try:
                     primi_polys.append(prim.polygon_data if hasattr(prim, "polygon_data") else prim.cast().polygon_data)

--- a/src/pyedb/grpc/database/primitive/primitive.py
+++ b/src/pyedb/grpc/database/primitive/primitive.py
@@ -32,6 +32,7 @@ from ansys.edb.core.database import ProductIdType as CoreProductIdType
 from ansys.edb.core.geometry.point_data import PointData as CorePointData
 from ansys.edb.core.layer.layer import LayerType as CoreLayerType
 from ansys.edb.core.primitive.circle import Circle as CoreCircle
+from ansys.edb.core.primitive.path import Path as CorePath
 
 from pyedb.generic.geometry_operators import GeometryOperators
 from pyedb.grpc.database.geometry.polygon_data import PolygonData
@@ -387,7 +388,55 @@ class Primitive:
 
         """
         if self.type == "path":
-            polygon = self._pedb.modeler.create_polygon(self.polygon_data, self.layer_name, [], self.net.name)
+            polygon_data = None
+
+            try:
+                polygon_data = self.core.cast().polygon_data
+                if not polygon_data.points:
+                    polygon_data = None
+            except Exception:
+                polygon_data = None
+
+            if polygon_data is None:
+                center_line = None
+                get_cached_center_line = getattr(self, "_get_cached_center_line_polygon_data", None)
+                if callable(get_cached_center_line):
+                    center_line = get_cached_center_line()
+
+                if center_line is None:
+                    try:
+                        center_line = self.core.center_line
+                    except Exception:
+                        center_line = None
+
+                if center_line is not None:
+                    polygon_data = CorePath.render(
+                        width=self.core.width,
+                        end_cap1=self.core.get_end_cap_style()[0],
+                        end_cap2=self.core.get_end_cap_style()[1],
+                        corner_style=self.core.corner_style,
+                        path=center_line,
+                    )
+
+            if polygon_data is None or not polygon_data.points:
+                get_fallback_polygon_points = getattr(self, "_get_fallback_polygon_points", None)
+                if callable(get_fallback_polygon_points):
+                    fallback_points = get_fallback_polygon_points()
+                    if fallback_points:
+                        polygon = self._pedb.modeler.create_polygon(
+                            fallback_points, self.layer_name, [], self.net_name or ""
+                        )
+                        if polygon:
+                            self.core.delete()
+                            self._pedb.modeler.clear_cache()
+                            return polygon
+
+                self._pedb.logger.error("Failed to create main shape polygon data")
+                return False
+
+            polygon = self._pedb.modeler.create_polygon(polygon_data, self.layer_name, [], self.net_name or "")
+            if not polygon:
+                return False
             self.core.delete()
             self._pedb.modeler.clear_cache()
             return polygon
@@ -568,26 +617,19 @@ class Primitive:
             List of Primitive objects.
 
         """
-        poly = self.core.cast().polygon_data
+        poly = self.core.polygon_data if hasattr(self.core, "polygon_data") else self.core.cast().polygon_data
         if not isinstance(primitives, list):
             primitives = [primitives]
         primi_polys = []
-        voids_of_prims = []
         for prim in primitives:
             if isinstance(prim, Primitive):
-                primi_polys.append(prim.core.cast().polygon_data)
-                for void in prim.voids:
-                    voids_of_prims.append(void.cast().polygon_data)
+                primi_polys.append(prim.core.polygon_data if hasattr(prim.core, "polygon_data") else prim.core.cast().polygon_data)
             else:
                 try:
-                    primi_polys.append(prim.cast().polygon_data)
+                    primi_polys.append(prim.polygon_data if hasattr(prim, "polygon_data") else prim.cast().polygon_data)
                 except:
                     primi_polys.append(prim)
-        for v in self.voids[:]:
-            primi_polys.append(v.polygon_data)
-        primi_polys = poly.unite(primi_polys)
-        p_to_sub = poly.unite([poly] + voids_of_prims)
-        list_poly = poly.subtract(p_to_sub, primi_polys)
+        list_poly = poly.subtract([poly], primi_polys)
         new_polys = []
         if list_poly:
             for p in list_poly:

--- a/src/pyedb/grpc/database/primitive/primitive.py
+++ b/src/pyedb/grpc/database/primitive/primitive.py
@@ -410,7 +410,9 @@ class Primitive:
             if callable(get_fallback_polygon_points):
                 fallback_points = get_fallback_polygon_points()
                 if fallback_points:
-                    polygon = self._pedb.modeler.create_polygon(fallback_points, self.layer_name, [], self.net_name or "")
+                    polygon = self._pedb.modeler.create_polygon(
+                        fallback_points, self.layer_name, [], self.net_name or ""
+                    )
                     if polygon:
                         self.core.delete()
                         self._pedb.modeler.clear_cache()

--- a/src/pyedb/grpc/database/primitive/primitive.py
+++ b/src/pyedb/grpc/database/primitive/primitive.py
@@ -387,61 +387,44 @@ class Primitive:
             Polygon when successful, ``False`` when failed.
 
         """
-        if self.type == "path":
-            polygon_data = None
-
-            try:
-                polygon_data = self.core.cast().polygon_data
-                if not polygon_data.points:
-                    polygon_data = None
-            except Exception:
-                polygon_data = None
-
-            if polygon_data is None:
-                center_line = None
-                get_cached_center_line = getattr(self, "_get_cached_center_line_polygon_data", None)
-                if callable(get_cached_center_line):
-                    center_line = get_cached_center_line()
-
-                if center_line is None:
-                    try:
-                        center_line = self.core.center_line
-                    except Exception:
-                        center_line = None
-
-                if center_line is not None:
-                    polygon_data = CorePath.render(
-                        width=self.core.width,
-                        end_cap1=self.core.get_end_cap_style()[0],
-                        end_cap2=self.core.get_end_cap_style()[1],
-                        corner_style=self.core.corner_style,
-                        path=center_line,
-                    )
-
-            if polygon_data is None or not polygon_data.points:
-                get_fallback_polygon_points = getattr(self, "_get_fallback_polygon_points", None)
-                if callable(get_fallback_polygon_points):
-                    fallback_points = get_fallback_polygon_points()
-                    if fallback_points:
-                        polygon = self._pedb.modeler.create_polygon(
-                            fallback_points, self.layer_name, [], self.net_name or ""
-                        )
-                        if polygon:
-                            self.core.delete()
-                            self._pedb.modeler.clear_cache()
-                            return polygon
-
-                self._pedb.logger.error("Failed to create main shape polygon data")
-                return False
-
-            polygon = self._pedb.modeler.create_polygon(polygon_data, self.layer_name, [], self.net_name or "")
-            if not polygon:
-                return False
-            self.core.delete()
-            self._pedb.modeler.clear_cache()
-            return polygon
-        else:
+        if self.type != "path":
             return False
+
+        polygon_data = self.core.cast().polygon_data
+        if not polygon_data.points:
+            get_cached_center_line = getattr(self, "_get_cached_center_line_polygon_data", None)
+            center_line = get_cached_center_line() if callable(get_cached_center_line) else None
+            if center_line is None:
+                center_line = self.core.center_line
+
+            polygon_data = CorePath.render(
+                width=self.core.width,
+                end_cap1=self.core.get_end_cap_style()[0],
+                end_cap2=self.core.get_end_cap_style()[1],
+                corner_style=self.core.corner_style,
+                path=center_line,
+            )
+
+        if not polygon_data.points:
+            get_fallback_polygon_points = getattr(self, "_get_fallback_polygon_points", None)
+            if callable(get_fallback_polygon_points):
+                fallback_points = get_fallback_polygon_points()
+                if fallback_points:
+                    polygon = self._pedb.modeler.create_polygon(fallback_points, self.layer_name, [], self.net_name or "")
+                    if polygon:
+                        self.core.delete()
+                        self._pedb.modeler.clear_cache()
+                        return polygon
+
+            self._pedb.logger.error("Failed to create main shape polygon data")
+            return False
+
+        polygon = self._pedb.modeler.create_polygon(polygon_data, self.layer_name, [], self.net_name or "")
+        if not polygon:
+            return False
+        self.core.delete()
+        self._pedb.modeler.clear_cache()
+        return polygon
 
     def intersection_type(self, primitive) -> int:
         """Get intersection type between actual primitive and another primitive or polygon data.

--- a/src/pyedb/grpc/database/utility/value.py
+++ b/src/pyedb/grpc/database/utility/value.py
@@ -28,6 +28,8 @@ class Value(float, CoreValue):
     """Class defining Edb Value properties."""
 
     def __new__(cls, val, owner=None) -> float:
+        if hasattr(val, "value_object"):
+            val = val.value_object
         if isinstance(val, (int, float)):
             inst = super().__new__(cls, val)
             inst.__core = None

--- a/src/pyedb/grpc/database/utility/value.py
+++ b/src/pyedb/grpc/database/utility/value.py
@@ -72,7 +72,7 @@ class Value(float, CoreValue):
         ):
             return self.__class__(float(self) + float(other))
         core = CoreValue(f"({str(self.core)})+({str(other)})", self.owner)
-        return self.__class__(core)
+        return self.__class__(core, self.owner)
 
     def __radd__(self, other):
         if self.__core is None and (
@@ -80,7 +80,7 @@ class Value(float, CoreValue):
         ):
             return self.__class__(float(self) + float(other))
         core = CoreValue(f"({str(other)})+({str(self.core)})", self.owner)
-        return self.__class__(core)
+        return self.__class__(core, self.owner)
 
     def __sub__(self, other):
         """Subtracts two Edb Values."""
@@ -89,7 +89,7 @@ class Value(float, CoreValue):
         ):
             return self.__class__(float(self) - float(other))
         core = CoreValue(f"({str(self.core)})-({str(other)})", self.owner)
-        return self.__class__(core)
+        return self.__class__(core, self.owner)
 
     def __rsub__(self, other):
         if self.__core is None and (
@@ -97,7 +97,7 @@ class Value(float, CoreValue):
         ):
             return self.__class__(float(other) - float(self))
         core = CoreValue(f"({str(other)})-({str(self.core)})", self.owner)
-        return self.__class__(core)
+        return self.__class__(core, self.owner)
 
     def __mul__(self, other):
         """Multiplies two Edb Values."""
@@ -106,7 +106,7 @@ class Value(float, CoreValue):
         ):
             return self.__class__(float(self) * float(other))
         core = CoreValue(f"({str(self.core)})*({str(other)})", self.owner)
-        return self.__class__(core)
+        return self.__class__(core, self.owner)
 
     def __rmul__(self, other):
         if self.__core is None and (
@@ -114,7 +114,7 @@ class Value(float, CoreValue):
         ):
             return self.__class__(float(other) * float(self))
         core = CoreValue(f"({str(other)})*({str(self.core)})", self.owner)
-        return self.__class__(core)
+        return self.__class__(core, self.owner)
 
     def __truediv__(self, other):
         """Divides two Edb Values."""
@@ -123,7 +123,7 @@ class Value(float, CoreValue):
         ):
             return self.__class__(float(self) / float(other))
         core = CoreValue(f"({str(self.core)})/({str(other)})", self.owner)
-        return self.__class__(core)
+        return self.__class__(core, self.owner)
 
     def __rtruediv__(self, other):
         if self.__core is None and (
@@ -131,7 +131,7 @@ class Value(float, CoreValue):
         ):
             return self.__class__(float(other) / float(self))
         core = CoreValue(f"({str(other)})/({str(self.core)})", self.owner)
-        return self.__class__(core)
+        return self.__class__(core, self.owner)
 
     @property
     def expression(self):
@@ -142,60 +142,60 @@ class Value(float, CoreValue):
         if self.__core is None:
             return self.__class__(float(self) ** 0.5)
         core = CoreValue(f"({str(self.core)})**0.5", self.owner)
-        return self.__class__(core)
+        return self.__class__(core, self.owner)
 
     def log10(self):
         """Base-10 logarithm of the value."""
         if self.__core is None:
             return self.__class__(math.log10(float(self)))
         core = CoreValue(f"log10({str(self.core)})", self.owner)
-        return self.__class__(core)
+        return self.__class__(core, self.owner)
 
     def sin(self):
         """Sine of the value."""
         if self.__core is None:
             return self.__class__(math.sin(float(self)))
         core = CoreValue(f"sin({str(self.core)})", self.owner)
-        return self.__class__(core)
+        return self.__class__(core, self.owner)
 
     def cos(self):
         """Cosine of the value."""
         if self.__core is None:
             return self.__class__(math.cos(float(self)))
         core = CoreValue(f"cos({str(self.core)})", self.owner)
-        return self.__class__(core)
+        return self.__class__(core, self.owner)
 
     def asin(self):
         """Arcsine of the value."""
         if self.__core is None:
             return self.__class__(math.asin(float(self)))
         core = CoreValue(f"asin({str(self.core)})", self.owner)
-        return self.__class__(core)
+        return self.__class__(core, self.owner)
 
     def acos(self):
         """Arccosine of the value."""
         if self.__core is None:
             return self.__class__(math.acos(float(self)))
         core = CoreValue(f"acos({str(self.core)})", self.owner)
-        return self.__class__(core)
+        return self.__class__(core, self.owner)
 
     def tan(self):
         """Tangent of the value."""
         if self.__core is None:
             return self.__class__(math.tan(float(self)))
         core = CoreValue(f"tan({str(self.core)})", self.owner)
-        return self.__class__(core)
+        return self.__class__(core, self.owner)
 
     def atan(self):
         """Arctangent of the value."""
         if self.__core is None:
             return self.__class__(math.atan(float(self)))
         core = CoreValue(f"atan({str(self.core)})", self.owner)
-        return self.__class__(core)
+        return self.__class__(core, self.owner)
 
     def __abs__(self):
         """Abs of the value."""
         if self.__core is None:
             return self.__class__(math.fabs(float(self)))
         core = CoreValue(f"abs({str(self.core)})", self.owner)
-        return self.__class__(core)
+        return self.__class__(core, self.owner)

--- a/src/pyedb/grpc/database/variables.py
+++ b/src/pyedb/grpc/database/variables.py
@@ -33,14 +33,14 @@ class Variable:
         self._name = name
 
     @property
-    def _is_design_varible(self):
+    def _is_design_variable(self):
         """Determines whether this variable is a design variable."""
         return not self.name.startswith("$")
 
     @property
     def _var_server(self):
         """Return the server containing this variable."""
-        return self._pedb.active_cell if self._is_design_varible else self._pedb.active_db
+        return self._pedb.active_cell if self._is_design_variable else self._pedb.active_db
 
     @property
     def name(self):

--- a/src/pyedb/grpc/database/variables.py
+++ b/src/pyedb/grpc/database/variables.py
@@ -48,14 +48,6 @@ class Variable:
         return self._name
 
     @property
-    def value_string(self):
-        """Get the string representation of this variable value."""
-        warnings.warn(
-            "`value_string` is deprecated. Use `str(value)` method instead.", DeprecationWarning, stacklevel=2
-        )
-        return str(self.value)
-
-    @property
     def value_object(self):
         """Get a symbolic value object bound to this variable name."""
         try:

--- a/src/pyedb/grpc/database/variables.py
+++ b/src/pyedb/grpc/database/variables.py
@@ -20,7 +20,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from ansys.edb.core.utility.value import Value as CoreValue
+import warnings
+
+from pyedb.grpc.database.utility.value import Value
 
 
 class Variable:
@@ -33,15 +35,33 @@ class Variable:
     @property
     def _is_design_varible(self):
         """Determines whether this variable is a design variable."""
-        if self.name.startswith("$"):
-            return False
-        else:
-            return True
+        return not self.name.startswith("$")
+
+    @property
+    def _var_server(self):
+        """Return the server containing this variable."""
+        return self._pedb.active_cell if self._is_design_varible else self._pedb.active_db
 
     @property
     def name(self):
         """Get the name of this variable."""
         return self._name
+
+    @property
+    def value_string(self):
+        """Get the string representation of this variable value."""
+        warnings.warn(
+            "`value_string` is deprecated. Use `str(value)` method instead.", DeprecationWarning, stacklevel=2
+        )
+        return str(self.value)
+
+    @property
+    def value_object(self):
+        """Get a symbolic value object bound to this variable name."""
+        try:
+            return Value(self.name, self._var_server)
+        except Exception:
+            return self._pedb.value(self.name)
 
     @property
     def value(self):
@@ -51,25 +71,29 @@ class Variable:
         -------
         float
         """
-        return CoreValue(self._pedb.get_variable_value(self.name))
+        return self._pedb.value(self._var_server.get_variable_value(self.name))
 
     @value.setter
     def value(self, value):
-        self._pedb.set_variable_value(self.name, CoreValue(value))
+        self._var_server.set_variable_value(self.name, self._pedb.value(value))
 
     @property
     def description(self):
         """Get the description of this variable."""
-        return self._pedb.get_variable_desc(self.name)
+        return self._var_server.get_variable_desc(self.name)
 
     @description.setter
     def description(self, value):
-        self._pedb.set_variable_desc(self.name, value)
+        self._var_server.set_variable_desc(name=self.name, desc=value)
 
     @property
     def is_parameter(self):
         """Determine whether this variable is a parameter."""
-        return self._pedb.is_parameter(self.name)
+        for method_name in ("is_variable_parameter", "is_parameter"):
+            method = getattr(self._var_server, method_name, None)
+            if callable(method):
+                return method(self.name)
+        return False
 
     def delete(self):
         """Delete this variable.
@@ -85,4 +109,71 @@ class Variable:
         >>> edb = Edb()
         >>> edb.design_variables["new_variable"].delete()
         """
-        return self._pedb.delete(self.name)
+        delete_method = getattr(self._var_server, "delete_variable", None)
+        if callable(delete_method):
+            return delete_method(self.name)
+        return False
+
+    def __float__(self):
+        return float(self.value)
+
+    def __str__(self):
+        return str(self.value_object)
+
+    def __repr__(self):
+        return f"Variable(name={self.name!r}, value={str(self.value)!r})"
+
+    def __add__(self, other):
+        return self.value_object + other
+
+    def __radd__(self, other):
+        return other + self.value_object
+
+    def __sub__(self, other):
+        return self.value_object - other
+
+    def __rsub__(self, other):
+        return other - self.value_object
+
+    def __mul__(self, other):
+        return self.value_object * other
+
+    def __rmul__(self, other):
+        return other * self.value_object
+
+    def __truediv__(self, other):
+        return self.value_object / other
+
+    def __rtruediv__(self, other):
+        return other / self.value_object
+
+    @property
+    def expression(self):
+        return self.name
+
+    def sqrt(self):
+        return self.value_object.sqrt()
+
+    def log10(self):
+        return self.value_object.log10()
+
+    def sin(self):
+        return self.value_object.sin()
+
+    def cos(self):
+        return self.value_object.cos()
+
+    def asin(self):
+        return self.value_object.asin()
+
+    def acos(self):
+        return self.value_object.acos()
+
+    def tan(self):
+        return self.value_object.tan()
+
+    def atan(self):
+        return self.value_object.atan()
+
+    def __abs__(self):
+        return abs(self.value_object)

--- a/src/pyedb/grpc/edb.py
+++ b/src/pyedb/grpc/edb.py
@@ -85,7 +85,6 @@ if TYPE_CHECKING:
     from pyedb.grpc.database.layout.voltage_regulator import VoltageRegulator
     from pyedb.grpc.database.simulation_setup.siwave_dcir_simulation_setup import SIWaveDCIRSimulationSetup
     from pyedb.grpc.database.utility.layout_statistics import LayoutStatistics
-import warnings
 from zipfile import ZipFile as Zpf
 
 from ansys.edb.core.geometry.polygon_data import PolygonData as CorePolygonData
@@ -463,8 +462,12 @@ class Edb(EdbInit):
             return None
         return None
 
-    def value(self, val) -> Value | float | str:
+    def value(self, val) -> Variable | Value | float | str:
         """Convert a value into a pyedb value."""
+        if isinstance(val, Variable):
+            return val.value_object
+        if isinstance(val, str) and self.variable_exists(val):
+            return self.variables[val]
         return Value(val, self.active_db) if isinstance(val, str) and "$" in val else Value(val, self.active_cell)
 
     def _value_setter(self, val) -> Value | float | str:
@@ -474,6 +477,12 @@ class Edb(EdbInit):
             return float(val) if isinstance(val, float) else val  # Return numeric values as-is
         except (ValueError, TypeError):
             return self.value(val)  # Convert strings with units or variables to Value objects
+
+    def _normalize_variable_value(self, variable_value: Any) -> Any:
+        """Convert variable proxy inputs to value objects before assignment."""
+        if isinstance(variable_value, Variable):
+            return variable_value.value_object
+        return variable_value
 
     @property
     def cell_names(self) -> List[str]:
@@ -495,7 +504,7 @@ class Edb(EdbInit):
         dict[str, Variable]
             Variable names and values.
         """
-        return {i: Variable(self.active_cell, i) for i in self.active_cell.get_all_variable_names()}
+        return {i: Variable(self, i) for i in self.active_cell.get_all_variable_names()}
 
     @property
     def project_variables(self) -> Dict[str, Variable]:
@@ -506,7 +515,7 @@ class Edb(EdbInit):
         dict[str, Variable]
             Variable names and values.
         """
-        return {i: Variable(self.active_db, i) for i in self.active_db.get_all_variable_names()}
+        return {i: Variable(self, i) for i in self.active_db.get_all_variable_names()}
 
     @property
     def layout_validation(self) -> LayoutValidation:
@@ -2069,7 +2078,7 @@ class Edb(EdbInit):
             return True
         return False
 
-    def get_variable(self, variable_name) -> Value | bool:
+    def get_variable(self, variable_name) -> Variable | bool:
         """Get variable value.
 
         Parameters
@@ -2079,16 +2088,11 @@ class Edb(EdbInit):
 
         Returns
         -------
-        float or bool
-            Variable value if exists, else False.
+        Variable or bool
+            Variable object if exists, else False.
         """
         if self.variable_exists(variable_name):
-            if variable_name.startswith("$"):
-                variable = next(var for var in self.active_db.get_all_variable_names())
-                return self.db.get_variable_value(variable)
-            else:
-                variable = next(var for var in self.active_cell.get_all_variable_names())
-                return self.active_cell.get_variable_value(variable)
+            return self.variables[variable_name]
         self.logger.info(f"Variable {variable_name} doesn't exists.")
         return False
 
@@ -2120,6 +2124,7 @@ class Edb(EdbInit):
         bool
             True if successful, False if variable exists.
         """
+        variable_value = self._normalize_variable_value(variable_value)
         if not variable_name.startswith("$"):
             variable_name = f"${variable_name}"
         if not self.variable_exists(variable_name):
@@ -2148,6 +2153,7 @@ class Edb(EdbInit):
         bool
             True if successful, False if variable exists.
         """
+        variable_value = self._normalize_variable_value(variable_value)
         if variable_name.startswith("$"):
             variable_name = variable_name[1:]
         if not self.variable_exists(variable_name):
@@ -2169,6 +2175,7 @@ class Edb(EdbInit):
         variable_value : str, float
             New value with units.
         """
+        variable_value = self._normalize_variable_value(variable_value)
         if self.variable_exists(variable_name):
             if variable_name in self.db.get_all_variable_names():
                 self.db.set_variable_value(variable_name, Value(variable_value))

--- a/src/pyedb/grpc/edb.py
+++ b/src/pyedb/grpc/edb.py
@@ -472,11 +472,14 @@ class Edb(EdbInit):
 
     def _value_setter(self, val) -> Value | float | str:
         """Helper for setting variable values with unit handling."""
+        val = self._normalize_variable_value(val)
+        if isinstance(val, Value):
+            return val
         try:
             float(val)
             return float(val) if isinstance(val, float) else val  # Return numeric values as-is
         except (ValueError, TypeError):
-            return self.value(val)  # Convert strings with units or variables to Value objects
+            return self._normalize_variable_value(self.value(val))  # Convert strings with units or variables to Value
 
     def _normalize_variable_value(self, variable_value: Any) -> Any:
         """Convert variable proxy inputs to value objects before assignment."""

--- a/tests/system/test_edb_database_utilities.py
+++ b/tests/system/test_edb_database_utilities.py
@@ -155,4 +155,3 @@ class TestDatabaseUtilities(BaseTestClass):
         assert float(edbapp.value("z")) == pytest.approx(float(z_obj))
 
         edbapp.close(terminate_rpc_session=False)
-

--- a/tests/system/test_edb_database_utilities.py
+++ b/tests/system/test_edb_database_utilities.py
@@ -23,6 +23,7 @@
 
 import pytest
 
+from pyedb.grpc.database.variables import Variable as GrpcVariable
 from tests import conftest
 from tests.conftest import config
 from tests.system.base_test_class import BaseTestClass
@@ -120,3 +121,38 @@ class TestDatabaseUtilities(BaseTestClass):
         assert str(value2) == "(var1)**0.5"
 
         edbapp.close(terminate_rpc_session=False)
+
+    @pytest.mark.skipif(
+        config["use_grpc"] and config["desktopVersion"] < "2026.1",
+        reason="Check issue #709 status in pyedb-core.",
+    )
+    def test_variable_value_workflow(self):
+        edbapp = self.edb_examples.create_empty_edb()
+
+        edbapp["x"] = "1mm"
+        edbapp["y"] = "2mm"
+
+        x_obj = edbapp.value("x")
+        y_obj = edbapp.value("y")
+
+        if conftest.config["use_grpc"]:
+            assert isinstance(x_obj, GrpcVariable)
+            assert isinstance(y_obj, GrpcVariable)
+
+        assert float(x_obj) == pytest.approx(0.001)
+        assert float(y_obj) == pytest.approx(0.002)
+        assert str(x_obj) == "x"
+        assert str(y_obj) == "y"
+
+        z_obj = x_obj + y_obj + y_obj
+        assert float(z_obj) > 0
+        assert str(z_obj) == "((x)+(y))+(y)"
+
+        edbapp.add_design_variable(variable_name="z", variable_value=z_obj)
+
+        assert edbapp.variable_exists("z")
+        assert edbapp["z"].value == pytest.approx(float(z_obj))
+        assert float(edbapp.value("z")) == pytest.approx(float(z_obj))
+
+        edbapp.close(terminate_rpc_session=False)
+

--- a/tests/unit/test_grpc_variables.py
+++ b/tests/unit/test_grpc_variables.py
@@ -1,0 +1,183 @@
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+
+from unittest.mock import MagicMock
+from typing import cast
+
+import pytest
+
+from pyedb.grpc.database.variables import Variable
+from pyedb.grpc.edb import Edb as GrpcEdb
+
+
+class FakeExpression:
+    def __init__(self, expression, numeric_value=None):
+        self.expression = str(expression)
+        self.numeric_value = numeric_value
+
+    def __str__(self):
+        return self.expression
+
+    def __float__(self):
+        if self.numeric_value is None:
+            raise TypeError(f"Expression {self.expression!r} does not have a numeric value.")
+        return float(self.numeric_value)
+
+    def _binary(self, operator, other, reverse=False):
+        left = other if reverse else self
+        right = self if reverse else other
+        other_value = float(other)
+        if operator == "+":
+            numeric_value = float(left) + float(right)
+        elif operator == "-":
+            numeric_value = float(left) - float(right)
+        elif operator == "*":
+            numeric_value = float(left) * float(right)
+        else:
+            numeric_value = float(left) / float(right)
+        return FakeExpression(f"({left}){operator}({right})", numeric_value)
+
+    def __add__(self, other):
+        return self._binary("+", other)
+
+    def __radd__(self, other):
+        return self._binary("+", other, reverse=True)
+
+    def __sub__(self, other):
+        return self._binary("-", other)
+
+    def __rsub__(self, other):
+        return self._binary("-", other, reverse=True)
+
+    def __mul__(self, other):
+        return self._binary("*", other)
+
+    def __rmul__(self, other):
+        return self._binary("*", other, reverse=True)
+
+    def __truediv__(self, other):
+        return self._binary("/", other)
+
+    def __rtruediv__(self, other):
+        return self._binary("/", other, reverse=True)
+
+    def sqrt(self):
+        return FakeExpression(f"({self})**0.5", float(self) ** 0.5)
+
+
+class FakeVariableServer:
+    def __init__(self, values, descriptions=None, parameters=None):
+        self.values = dict(values)
+        self.descriptions = dict(descriptions or {})
+        self.parameters = set(parameters or [])
+
+    def get_all_variable_names(self):
+        return list(self.values)
+
+    def get_variable_value(self, name):
+        return self.values[name]
+
+    def set_variable_value(self, name, value):
+        self.values[name] = value
+
+    def get_variable_desc(self, name):
+        return self.descriptions.get(name, "")
+
+    def set_variable_desc(self, name, desc):
+        self.descriptions[name] = desc
+
+    def is_variable_parameter(self, name):
+        return name in self.parameters
+
+    def delete_variable(self, name):
+        self.values.pop(name, None)
+        self.descriptions.pop(name, None)
+        self.parameters.discard(name)
+        return True
+
+
+class FakePedb:
+    def __init__(self):
+        self.active_cell = FakeVariableServer(
+            {"x": 1.0, "y": 2.0},
+            descriptions={"x": "x variable"},
+            parameters={"x"},
+        )
+        self.active_db = FakeVariableServer(
+            {"$g": 3.0},
+            descriptions={"$g": "project variable"},
+            parameters={"$g"},
+        )
+
+    def value(self, value):
+        if isinstance(value, Variable):
+            return self.value(value.name)
+        if isinstance(value, FakeExpression):
+            return value
+        if isinstance(value, str):
+            if value in self.active_cell.values:
+                return FakeExpression(value, self.active_cell.values[value])
+            if value in self.active_db.values:
+                return FakeExpression(value, self.active_db.values[value])
+        return FakeExpression(value, value)
+
+
+@pytest.mark.unit
+def test_grpc_variable_symbolic_arithmetic_uses_variable_names():
+    pedb = FakePedb()
+
+    x_obj = Variable(pedb, "x")
+    y_obj = Variable(pedb, "y")
+    z_obj = x_obj + y_obj + y_obj
+
+    assert str(x_obj) == "x"
+    assert float(x_obj) == pytest.approx(1.0)
+    assert str(z_obj) == "((x)+(y))+(y)"
+    assert float(z_obj) == pytest.approx(5.0)
+
+
+@pytest.mark.unit
+def test_grpc_variable_routes_metadata_and_mutations_to_correct_server():
+    pedb = FakePedb()
+
+    design_variable = Variable(pedb, "x")
+    project_variable = Variable(pedb, "$g")
+
+    assert design_variable.description == "x variable"
+    assert project_variable.description == "project variable"
+    assert design_variable.is_parameter is True
+    assert project_variable.is_parameter is True
+
+    design_variable.description = "updated design variable"
+    project_variable.value = 4.5
+
+    assert pedb.active_cell.descriptions["x"] == "updated design variable"
+    assert float(pedb.active_db.values["$g"]) == pytest.approx(4.5)
+
+    assert project_variable.delete() is True
+    assert "$g" not in pedb.active_db.get_all_variable_names()
+
+
+@pytest.mark.unit
+def test_grpc_edb_returns_variable_proxies_for_existing_variables():
+    edb = GrpcEdb.__new__(GrpcEdb)
+    edb._db = FakeVariableServer({"$g": 3.0})
+    edb._active_cell = FakeVariableServer({"x": 1.0, "y": 2.0})
+    edb.logger = MagicMock()
+
+    design_variable = edb.get_variable("x")
+    project_variable = edb.get_variable("$g")
+    design_variables = cast(dict[str, Variable], cast(object, edb.design_variables))
+    project_variables = cast(dict[str, Variable], cast(object, edb.project_variables))
+
+    assert isinstance(design_variable, Variable)
+    assert isinstance(project_variable, Variable)
+    assert isinstance(edb.value("x"), Variable)
+    assert isinstance(edb.value("$g"), Variable)
+    assert design_variable.name == "x"
+    assert project_variable.name == "$g"
+    assert edb["y"].name == "y"
+    assert design_variables["x"]._pedb is edb
+    assert project_variables["$g"]._pedb is edb
+    assert edb.get_variable("missing") is False
+

--- a/tests/unit/test_grpc_variables.py
+++ b/tests/unit/test_grpc_variables.py
@@ -1,8 +1,8 @@
 # Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 
-from unittest.mock import MagicMock
 from typing import cast
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -180,4 +180,3 @@ def test_grpc_edb_returns_variable_proxies_for_existing_variables():
     assert design_variables["x"]._pedb is edb
     assert project_variables["$g"]._pedb is edb
     assert edb.get_variable("missing") is False
-


### PR DESCRIPTION
Summary:
-----------
Improve gRPC variable/value handling so existing variables behave more like DotNet variable-server objects.
Changes
* return gRPC variable proxies from Edb.value("var") for existing variables
* support symbolic arithmetic on gRPC variables
* preserve owner context for chained expressions
* allow direct reuse of variable expressions when adding design variables
* add mirrored system coverage for DotNet-style workflows

Validation:
* focused unit tests passed
* focused system tests passed in both default and USE_GRPC=1 modes

Behavior enabled
``` python
app["x"] = "1mm"
app["y"] = "2mm"

x_obj = app.value("x")
y_obj = app.value("y")

z_obj = x_obj + y_obj

print(float(z_obj), str(z_obj))
app.add_design_variable("z", z_obj)
```
closes #2005 
closes #2016 
