### PR TITLE
FIX: guard gRPC layout terminal enumeration against null terminals

### DIFF
--- a/doc/changelog.d/2040.fixed.md
+++ b/doc/changelog.d/2040.fixed.md
@@ -1,0 +1,1 @@
+Guard gRPC layout terminal enumeration against null terminals

--- a/src/pyedb/grpc/database/layout/layout.py
+++ b/src/pyedb/grpc/database/layout/layout.py
@@ -515,16 +515,31 @@ class Layout(PrimitivesQuery):
             Dictionary of terminals.
         """
         temp = []
-        for i in self._pedb.active_cell.layout.terminals:
-            if i.type.name.lower() == "pin_group":
+        try:
+            raw_terminals = self._pedb.active_cell.layout.terminals
+        except Exception as exc:
+            self._pedb.logger.warning("Failed to enumerate raw layout terminals: %s", exc)
+            return temp
+
+        for i in raw_terminals:
+            if i is None:
+                continue
+            try:
+                type_name_obj = i.type.name
+            except Exception as exc:
+                self._pedb.logger.warning("Skipping invalid terminal object during enumeration: %s", exc)
+                continue
+
+            type_name = type_name_obj.lower()
+            if type_name == "pin_group":
                 temp.append(PinGroupTerminal(self._pedb, i))
-            elif i.type.name.lower() == "padstack_inst":
+            elif type_name == "padstack_inst":
                 temp.append(PadstackInstanceTerminal(self._pedb, i))
-            elif i.type.name.lower() == "edge":
+            elif type_name == "edge":
                 temp.append(EdgeTerminal(self._pedb, i))
-            elif i.type.name.lower() == "bundle":
+            elif type_name == "bundle":
                 temp.append(BundleTerminal(self._pedb, i))
-            elif i.type.name.lower() == "point":
+            elif type_name == "point":
                 temp.append(PointTerminal(self._pedb, i))
         return temp
 

--- a/tests/unit/test_grpc_layout_terminals.py
+++ b/tests/unit/test_grpc_layout_terminals.py
@@ -1,0 +1,78 @@
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from pyedb.grpc.database.layout.layout import Layout
+
+
+def _terminal_with_type(name: str) -> object:
+    return SimpleNamespace(type=SimpleNamespace(name=name))
+
+
+class _BrokenTerminal:
+    @property
+    def type(self) -> object:
+        raise RuntimeError("broken terminal")
+
+
+class _BrokenCoreLayout:
+    @property
+    def terminals(self) -> object:
+        raise RuntimeError("layout terminal enumeration failed")
+
+
+def _build_layout_with_terminals(raw_terminals: object) -> Layout:
+    pedb = SimpleNamespace(
+        active_cell=SimpleNamespace(layout=SimpleNamespace(terminals=raw_terminals)),
+        logger=SimpleNamespace(warning=lambda *_args, **_kwargs: None),
+    )
+    return Layout(pedb=pedb, core=SimpleNamespace(layout_instance=None))
+
+
+def test_layout_terminals_skips_invalid_entries() -> None:
+    layout = _build_layout_with_terminals(
+        [
+            _terminal_with_type("pin_group"),
+            _BrokenTerminal(),
+            None,
+            _terminal_with_type("point"),
+        ]
+    )
+
+    terminals = layout.terminals
+
+    assert len(terminals) == 2
+    assert terminals[0].terminal_type == "pin_group"
+    assert terminals[1].terminal_type == "point"
+
+
+def test_layout_terminals_returns_empty_when_core_enumeration_fails() -> None:
+    pedb = SimpleNamespace(
+        active_cell=SimpleNamespace(layout=_BrokenCoreLayout()),
+        logger=SimpleNamespace(warning=lambda *_args, **_kwargs: None),
+    )
+    layout = Layout(pedb=pedb, core=SimpleNamespace(layout_instance=None))
+
+    assert layout.terminals == []


### PR DESCRIPTION
## Summary
- guard gRPC layout terminal enumeration against `None` and invalid terminal objects
- add focused unit coverage for invalid terminal entries and enumeration failure

## Notes
- This replaces the earlier fork-based PR so CI can run without fork OIDC/provenance restrictions.

closes #2028