### PR TITLE
CI: Fix pyaedt testing missing dependencies

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -560,7 +560,7 @@ jobs:
         run: |
           . .venv\Scripts\Activate.ps1
           cd external/pyaedt
-          pip install --no-cache-dir --group tests .
+          pip install --no-cache-dir --group tests .[all]
 
       - name: Install PyEDB
         run: |
@@ -667,7 +667,7 @@ jobs:
         run: |
           . .venv/bin/activate
           cd external/pyaedt
-          pip install --no-cache-dir --group tests .
+          pip install --no-cache-dir --group tests .[all]
 
       - name: Install PyEDB
         env:

--- a/doc/changelog.d/2042.maintenance.md
+++ b/doc/changelog.d/2042.maintenance.md
@@ -1,0 +1,1 @@
+Fix pyaedt testing missing dependencies


### PR DESCRIPTION
As title says. Given recent changes in pyaedt, the target to be used for testing has been updated.