### PR TITLE
FIX: Multiple edb load fix

### DIFF
--- a/doc/changelog.d/2066.fixed.md
+++ b/doc/changelog.d/2066.fixed.md
@@ -1,0 +1,1 @@
+Multiple edb load fix

--- a/src/pyedb/generic/design_types.py
+++ b/src/pyedb/generic/design_types.py
@@ -368,7 +368,6 @@ def Edb(
 
     grpc = grpc if grpc is not None else _use_grpc_by_default(settings.specified_version)
     settings.is_grpc = grpc
-    settings.is_in_memory = in_memory if grpc else False
 
     if grpc:
         if 2025.2 <= float(settings.specified_version) <= 2027.1:
@@ -386,7 +385,6 @@ def Edb(
                 map_file=map_file,
                 technology_file=technology_file,
                 control_file=control_file,
-                in_memory=in_memory,
             )
 
         elif float(settings.specified_version) < 2025.2:

--- a/src/pyedb/grpc/edb.py
+++ b/src/pyedb/grpc/edb.py
@@ -193,9 +193,6 @@ class Edb(EdbInit):
         Layer filter file for import.
     restart_rpc_server : bool, optional
         Restart gRPC server. Use with caution. Default False.
-    in_memory : bool, optional
-        Whether to use the in-memory gRPC transport when available. The default is ``True``.
-        If the required native library is unavailable, PyEDB falls back to the standard socket-based RPC session.
 
     Examples
     --------
@@ -228,12 +225,10 @@ class Edb(EdbInit):
         technology_file: str = None,
         layer_filter: str = None,
         restart_rpc_server=False,
-        in_memory: bool = True,
     ):
         edbversion = get_string_version(version)
         self._clean_variables()
-        EdbInit.__init__(self, version=version, in_memory=in_memory)
-        self.in_memory = in_memory
+        EdbInit.__init__(self, version=version)
         self.standalone = True
         self.oproject = oproject
         self._main = sys.modules["__main__"]
@@ -326,13 +321,13 @@ class Edb(EdbInit):
                 raise AttributeError("Translation was unsuccessful")
         elif edbpath.endswith("edb.def"):
             self.edbpath = os.path.dirname(edbpath)
-            self.open(restart_rpc_server=restart_rpc_server, in_memory=self.in_memory)
+            self.open(restart_rpc_server=restart_rpc_server)
         elif not os.path.exists(os.path.join(self.edbpath, "edb.def")):
             self.create(restart_rpc_server=restart_rpc_server)
             self.logger.info("EDB %s created correctly.", self.edbpath)
         elif ".aedb" in edbpath:
             self.edbpath = edbpath
-            self.open(restart_rpc_server=restart_rpc_server, in_memory=self.in_memory)
+            self.open(restart_rpc_server=restart_rpc_server)
         if self.active_cell:
             self.logger.info("EDB initialized.")
         else:
@@ -692,7 +687,7 @@ class Edb(EdbInit):
         ]
         return {ter.name: ter for ter in terms}
 
-    def open(self, restart_rpc_server: bool = False, in_memory: bool | None = None) -> bool:
+    def open(self, restart_rpc_server: bool = False) -> bool:
         """Open EDB database.
 
         Returns
@@ -705,20 +700,11 @@ class Edb(EdbInit):
         >>> # Open an existing EDB database:
         >>> edb = Edb("myproject.aedb")
         """
-        if in_memory is None:
-            in_memory = self.in_memory
-        else:
-            self.in_memory = in_memory
         self.standalone = self.standalone
         n_try = 10
         while not self.db and n_try:
             try:
-                self._open(
-                    self.edbpath,
-                    self.isreadonly,
-                    restart_rpc_server=restart_rpc_server,
-                    in_memory=in_memory,
-                )
+                self._open(self.edbpath, self.isreadonly, restart_rpc_server=restart_rpc_server)
                 n_try -= 1
             except Exception as e:
                 self.logger.error(e.args[0])
@@ -758,7 +744,7 @@ class Edb(EdbInit):
         n_try = 10
         while not self.db and n_try:
             try:
-                self._create(self.edbpath, restart_rpc_server=restart_rpc_server, in_memory=self.in_memory)
+                self._create(self.edbpath, restart_rpc_server=restart_rpc_server)
                 n_try -= 1
             except Exception as e:
                 self.logger.error(e.args[0])
@@ -936,7 +922,7 @@ class Edb(EdbInit):
             self.logger.info("Translation successfully completed")
         self.edbpath = os.path.join(working_dir, aedb_name)
         # open_edb is deprecated; use open() here to silence deprecation warnings
-        return self.open(in_memory=self.in_memory)
+        return self.open()
 
     def import_vlctech_stackup(
         self,
@@ -991,7 +977,7 @@ class Edb(EdbInit):
         else:
             self.logger.info("edb successfully created.")
         self.edbpath = os.path.join(working_dir, "vlctech.aedb")
-        self.open(in_memory=self.in_memory)
+        self.open()
         return self.edbpath
 
     def export_to_ipc2581(self, edbpath="", anstranslator_full_path="", ipc_path=None) -> str:
@@ -1645,7 +1631,7 @@ class Edb(EdbInit):
                 raise RuntimeError("An error occurred while converting file") from e
             temp_input_gds = input_gds.split(".gds")[0]
             self.edbpath = temp_input_gds + ".aedb"
-            return self.open(in_memory=self.in_memory)
+            return self.open()
 
     @deprecate_argument_name({"signal_list": "signal_nets", "reference_list": "reference_nets"})
     def cutout(
@@ -2530,7 +2516,7 @@ class Edb(EdbInit):
         defined_ports = {}
         project_connexions = None
         for edb_path, zone_info in zones.items():
-            edb = Edb(edbversion=self.version, edbpath=edb_path, in_memory=self.in_memory)
+            edb = Edb(edbversion=self.version, edbpath=edb_path)
             edb.cutout(
                 use_pyaedt_cutout=True,
                 custom_extent=zone_info[1],
@@ -2970,7 +2956,7 @@ class Edb(EdbInit):
             self.save()
             self.close()
             self.edbpath = edb_original_path
-            self.open(in_memory=self.in_memory)
+            self.open()
         return parameters
 
     @staticmethod
@@ -3093,7 +3079,6 @@ class Edb(EdbInit):
             edbpath=output_edb,
             edbversion=self.version,
             restart_rpc_server=True,
-            in_memory=self.in_memory,
         )
 
         cloned_edb.stackup.add_layer(
@@ -3346,7 +3331,7 @@ class Edb(EdbInit):
 
     def copy_cell_from_edb(self, edb_path: Union[Path, str]):
         """Copy Cells from another Edb Database into this Database."""
-        edb2 = Edb(edbpath=edb_path, edbversion=self.version, in_memory=self.in_memory)
+        edb2 = Edb(edbpath=edb_path, edbversion=self.version)
         try:
             cells = self.copy_cells([edb2.active_cell])
             cell = cells[0]

--- a/src/pyedb/grpc/edb_init.py
+++ b/src/pyedb/grpc/edb_init.py
@@ -41,7 +41,7 @@ from pyedb.grpc.rpc_session import RpcSession
 class EdbInit(object):
     """Edb Dot Net Class."""
 
-    def __init__(self, version, in_memory=False, is_linux=False):
+    def __init__(self, version, is_linux=False):
         """
         Initialize the gRPC EDB database helper.
 
@@ -49,8 +49,6 @@ class EdbInit(object):
         ----------
         version : str
             AEDT/EDB version to initialize, for example ``"2026.1"``.
-        in_memory : bool, optional
-            Whether to request the local in-memory gRPC transport. The default is ``False``.
         is_linux : bool, optional
             Whether to initialize environment paths using the Linux-specific startup flow.
             The default is ``False``.
@@ -79,13 +77,12 @@ class EdbInit(object):
         os.environ["ECAD_TRANSLATORS_INSTALL_DIR"] = self.base_path
         oa_directory = os.path.join(self.base_path, "common", "oa")
         os.environ["ANSYS_OADIR"] = oa_directory
-        os.environ["PATH"] = "{};{}".format(os.environ["PATH"], self.base_path)
+        os.environ["PATH"] = os.pathsep.join([os.environ["PATH"], self.base_path])
         # register server kill
         atexit.register(self._signal_handler)
         # register signal handlers
         signal.signal(signal.SIGTERM, self._signal_handler)
         signal.signal(signal.SIGINT, self._signal_handler)
-        RpcSession.in_memory = in_memory
 
     @staticmethod
     def _signal_handler(signum=None, frame=None):
@@ -96,13 +93,7 @@ class EdbInit(object):
         """Active database object."""
         return self._db
 
-    def _sync_transport_mode(self):
-        """Synchronize the effective transport mode after session startup or fallback."""
-        settings.is_in_memory = RpcSession.in_memory
-        if hasattr(self, "in_memory"):
-            self.in_memory = RpcSession.in_memory
-
-    def _create(self, db_path, port=0, restart_rpc_server=False, in_memory=False):
+    def _create(self, db_path, port=0, restart_rpc_server=False):
         """Create a Database at the specified file location.
 
         Parameters
@@ -110,31 +101,30 @@ class EdbInit(object):
         db_path : str
             Path to top-level database folder
 
-        port : int
-            grpc port number.
+        port : int, optional
+            gRPC port number. The default is ``0`` (auto-select).
 
-        restart_rpc_server : optional, bool
-            Force restarting RPC server when `True`.Default value is `False`
+        restart_rpc_server : bool, optional
+            Force restarting RPC server when ``True``. The default is ``False``.
 
         Returns
         -------
         Database
         """
-        RpcSession.in_memory = in_memory
         RpcSession.start(
             edb_version=self.version,
             port=port,
             restart_server=restart_rpc_server,
         )
-        self._sync_transport_mode()
         if not RpcSession.rpc_session:
             self.logger.error("Failed to start RPC server.")
             return False
-
         self._db = database.Database.create(db_path)
+        if self._db:
+            RpcSession.acquire()
         return self._db
 
-    def _open(self, db_path, read_only, port=0, restart_rpc_server=False, in_memory=False):
+    def _open(self, db_path, read_only, port=0, restart_rpc_server=False):
         """Open an existing Database at the specified file location.
 
         Parameters
@@ -143,27 +133,27 @@ class EdbInit(object):
             Path to top-level Database folder.
         read_only : bool
             Obtain read-only access.
-        port : optional, int.
-            Specify the port number. If not provided a randon free one is selected. Default value is `0`.
-        restart_rpc_server : optional, bool
-            Force restarting RPC server when `True`. Default value is `False`.
+        port : int, optional
+            Port number. If not provided a random free one is selected. The default is ``0``.
+        restart_rpc_server : bool, optional
+            Force restarting RPC server when ``True``. The default is ``False``.
 
         Returns
         -------
         Database or None
             The opened Database object, or None if not found.
         """
-        RpcSession.in_memory = in_memory
         RpcSession.start(
             edb_version=self.version,
             port=port,
             restart_server=restart_rpc_server,
         )
-        self._sync_transport_mode()
         if not RpcSession.rpc_session:
             self.logger.error("Failed to start RPC server.")
             return False
         self._db = database.Database.open(db_path, read_only)
+        if self._db:
+            RpcSession.acquire()
         return self._db
 
     def delete(self, db_path):
@@ -203,24 +193,27 @@ class EdbInit(object):
         else:
             return False
 
-    def close(self, terminate_rpc_session=True):
+    def close(self, terminate_rpc_session=False):
         """Close the database.
 
         Parameters
         ----------
         terminate_rpc_session : bool, optional
-            Terminate RPC session when closing the database. The default value is `True`.
+            Force termination of the RPC session regardless of how many other databases are still
+            open. The default is ``False``, meaning the RPC server is only shut down automatically
+            when the **last** open database is closed (reference-counted).
 
-        . note::
-            Unsaved changes will be lost. If multiple databases are open and RPC session is terminated, the connection
-            with all databases will be lost. You might be careful and set to `False` until the last open database
-            remains.
+        Notes
+        -----
+        Unsaved changes will be lost. When ``terminate_rpc_session=True`` and multiple databases
+        are open, all connections will be lost immediately.
         """
         self._db.close()
         self._db = None
         if terminate_rpc_session:
             RpcSession.close()
-            self._sync_transport_mode()
+        else:
+            RpcSession.release()
         self._clean_variables()
         return True
 

--- a/src/pyedb/grpc/rpc_session.py
+++ b/src/pyedb/grpc/rpc_session.py
@@ -63,13 +63,15 @@ class RpcSession:
 
     @staticmethod
     def release():
-        """Decrement the open-database reference counter and shut down the server when it reaches zero.
+        """
+        Decrement the open-database reference counter and shut down the server when it reaches zero.
 
         Returns
         -------
         bool
             ``True`` if the RPC session was terminated (last database closed),
             ``False`` if other databases are still open and the session was kept alive.
+
         """
         if RpcSession._open_db_count > 0:
             RpcSession._open_db_count -= 1

--- a/src/pyedb/grpc/rpc_session.py
+++ b/src/pyedb/grpc/rpc_session.py
@@ -25,14 +25,6 @@ import secrets
 import sys
 import time
 
-try:
-    from ansys.edb.core.session import is_in_memory
-except ImportError:
-
-    def is_in_memory():
-        return False
-
-
 from ansys.edb.core.session import launch_session
 from ansys.edb.core.utility.io_manager import (
     IOMangementType,
@@ -56,8 +48,6 @@ class RpcSession:
     rpc_session = None
     base_path = None
     port = 10000
-    server_pid = 0
-    in_memory = False
 
     @staticmethod
     def start(edb_version, port=0, restart_server=False):
@@ -114,44 +104,20 @@ class RpcSession:
         os.environ["ANSYS_OADIR"] = oa_directory
         os.environ["PATH"] = "{};{}".format(os.environ["PATH"], RpcSession.base_path)
 
-        requested_in_memory = RpcSession.in_memory
-        current_in_memory = is_in_memory() if RpcSession.rpc_session else None
-
-        if RpcSession.rpc_session:
-            if restart_server or current_in_memory != requested_in_memory:
-                reason = "restart requested" if restart_server else "transport mode changed"
-                settings.logger.info(f"Restarting gRPC session because {reason}.")
-                RpcSession.close()
-                RpcSession.in_memory = requested_in_memory
-            elif current_in_memory:
-                settings.logger.info("gRPC session already running in local in-memory mode.")
-                settings.is_in_memory = True
-                return
+        if RpcSession.pid:
+            if restart_server:
+                settings.logger.logger.info("Restarting RPC server")
+                RpcSession.kill()
+                RpcSession.__start_rpc_server()
             else:
                 settings.logger.info(f"Server already running on port {RpcSession.port}")
-                settings.is_in_memory = False
-                return
-
-        session_started = False
-        if RpcSession.in_memory:
-            RpcSession.__start_rpc_server()
-            session_started = True
-            RpcSession.in_memory = is_in_memory()
-            if RpcSession.rpc_session and RpcSession.in_memory:
-                settings.logger.info("Grpc session started in local mode (fast)")
-                settings.is_in_memory = True
-                return
-            if RpcSession.rpc_session:
-                settings.logger.info("In-memory transport unavailable. Falling back to standard gRPC transport.")
-
-        if not session_started:
-            RpcSession.__start_rpc_server()
-        if RpcSession.rpc_session:
-            RpcSession.server_pid = RpcSession.rpc_session.local_server_proc.pid
-            settings.logger.info(f"Grpc session started: pid={RpcSession.server_pid}")
         else:
-            settings.logger.error("Failed to start EDB_RPC_server process")
-        settings.is_in_memory = RpcSession.in_memory
+            RpcSession.__start_rpc_server()
+            if RpcSession.rpc_session:
+                RpcSession.server_pid = RpcSession.rpc_session.local_server_proc.pid
+                settings.logger.info(f"Grpc session started: pid={RpcSession.server_pid}")
+            else:
+                settings.logger.error("Failed to start EDB_RPC_server process")
 
     @staticmethod
     def __get_process_id():
@@ -165,8 +131,7 @@ class RpcSession:
     @staticmethod
     def __start_rpc_server():
         RpcSession.rpc_session = launch_session(RpcSession.base_path, port_num=RpcSession.port)
-        if not is_in_memory():
-            start_managing(IOMangementType.READ_AND_WRITE)
+        start_managing(IOMangementType.READ_AND_WRITE)
         time.sleep(latency_delay)
         if RpcSession.rpc_session:
             RpcSession.pid = RpcSession.rpc_session.local_server_proc.pid
@@ -174,7 +139,6 @@ class RpcSession:
 
     @staticmethod
     def kill():
-        """Kill RPC process."""
         p = psutil.Process(RpcSession.pid)
         time.sleep(latency_delay)
         try:
@@ -186,7 +150,6 @@ class RpcSession:
 
     @staticmethod
     def kill_all_instances():
-        """Kill all RPC process."""
         # collect PIDs safely
         proc = []
         for p in psutil.process_iter(["pid", "name"]):
@@ -212,13 +175,10 @@ class RpcSession:
         If not executed, users should force restarting the process using the flag `restart_server`=`True`.
         """
         if RpcSession.rpc_session:
-            if not RpcSession.in_memory:
-                end_managing()
+            end_managing()
             RpcSession.rpc_session.disconnect()
             time.sleep(latency_delay)
-            RpcSession.rpc_session = None
-        RpcSession.pid = 0
-        RpcSession.server_pid = 0
+            RpcSession.__get_process_id()
 
     @staticmethod
     def __get_random_free_port():

--- a/src/pyedb/grpc/rpc_session.py
+++ b/src/pyedb/grpc/rpc_session.py
@@ -48,6 +48,36 @@ class RpcSession:
     rpc_session = None
     base_path = None
     port = 10000
+    server_pid = 0
+    _open_db_count = 0  # number of EDB databases currently open against this server
+
+    @staticmethod
+    def acquire():
+        """Increment the open-database reference counter.
+
+        Must be called each time a database is successfully created or opened so that
+        the RPC server is not shut down while other databases are still in use.
+        """
+        RpcSession._open_db_count += 1
+        settings.logger.info(f"RPC session acquired (open databases: {RpcSession._open_db_count})")
+
+    @staticmethod
+    def release():
+        """Decrement the open-database reference counter and shut down the server when it reaches zero.
+
+        Returns
+        -------
+        bool
+            ``True`` if the RPC session was terminated (last database closed),
+            ``False`` if other databases are still open and the session was kept alive.
+        """
+        if RpcSession._open_db_count > 0:
+            RpcSession._open_db_count -= 1
+        settings.logger.info(f"RPC session released (open databases: {RpcSession._open_db_count})")
+        if RpcSession._open_db_count == 0:
+            RpcSession.close()
+            return True
+        return False
 
     @staticmethod
     def start(edb_version, port=0, restart_server=False):
@@ -102,12 +132,12 @@ class RpcSession:
         os.environ["ECAD_TRANSLATORS_INSTALL_DIR"] = RpcSession.base_path
         oa_directory = os.path.join(RpcSession.base_path, "common", "oa")
         os.environ["ANSYS_OADIR"] = oa_directory
-        os.environ["PATH"] = "{};{}".format(os.environ["PATH"], RpcSession.base_path)
+        os.environ["PATH"] = os.pathsep.join([os.environ["PATH"], RpcSession.base_path])
 
-        if RpcSession.pid:
+        if RpcSession.rpc_session:
             if restart_server:
-                settings.logger.logger.info("Restarting RPC server")
-                RpcSession.kill()
+                settings.logger.info("Restarting RPC server.")
+                RpcSession.close()
                 RpcSession.__start_rpc_server()
             else:
                 settings.logger.info(f"Server already running on port {RpcSession.port}")
@@ -178,7 +208,10 @@ class RpcSession:
             end_managing()
             RpcSession.rpc_session.disconnect()
             time.sleep(latency_delay)
-            RpcSession.__get_process_id()
+            RpcSession.rpc_session = None
+        RpcSession.pid = 0
+        RpcSession.server_pid = 0
+        RpcSession._open_db_count = 0
 
     @staticmethod
     def __get_random_free_port():

--- a/tests/system/test_edb.py
+++ b/tests/system/test_edb.py
@@ -1388,7 +1388,7 @@ class TestClass(BaseTestClass):
         assert list(edb1.components.instances.values())[0].name == "U0"
         assert len(list(edb2.components.instances.values())) == 509
         assert list(edb2.components.instances.values())[0].name == "C380"
-        edb1.close() # testing server RPC should not be closed
+        edb1.close()  # testing server RPC should not be closed
         assert edb1.active_cell is None
         assert len(list(edb2.components.instances.values())) == 509
         assert list(edb2.components.instances.values())[0].name == "C380"

--- a/tests/system/test_edb.py
+++ b/tests/system/test_edb.py
@@ -1379,3 +1379,18 @@ class TestClass(BaseTestClass):
             edbapp.excitation_manager.create_horizontal_wave_port(void)
         assert len(edbapp.ports) == 6
         edbapp.close(terminate_rpc_session=False)
+
+    def test_load_multiple_edb(self):
+        edb1 = self.edb_examples.get_si_board()
+        assert len(list(edb1.components.instances.values())) == 4
+        assert list(edb1.components.instances.values())[0].name == "U0"
+        edb2 = self.edb_examples.get_si_verse()
+        assert list(edb1.components.instances.values())[0].name == "U0"
+        assert len(list(edb2.components.instances.values())) == 509
+        assert list(edb2.components.instances.values())[0].name == "C380"
+        edb1.close() # testing server RPC should not be closed
+        assert edb1.active_cell is None
+        assert len(list(edb2.components.instances.values())) == 509
+        assert list(edb2.components.instances.values())[0].name == "C380"
+        edb2.close(terminate_rpc_session=False)
+        assert edb2.active_cell is None

--- a/tests/unit/test_design_types.py
+++ b/tests/unit/test_design_types.py
@@ -22,11 +22,12 @@
 
 import sys
 from types import ModuleType
-from tests.conftest import config
+
 import pytest
 
 from pyedb.generic import design_types
 from pyedb.generic.settings import settings
+from tests.conftest import config
 
 
 @pytest.fixture

--- a/tests/unit/test_design_types.py
+++ b/tests/unit/test_design_types.py
@@ -22,7 +22,7 @@
 
 import sys
 from types import ModuleType
-
+from tests.conftest import config
 import pytest
 
 from pyedb.generic import design_types
@@ -84,6 +84,7 @@ def fake_backends(monkeypatch):
     monkeypatch.setitem(sys.modules, "pyedb.dotnet.edb", dotnet_module)
 
 
+@pytest.mark.skipif(not config["use_grpc"], reason="Applies only for grpc.")
 def test_edb_defaults_to_grpc_for_2026_1_and_later(restore_settings_state, fake_backends):
     with pytest.warns(UserWarning):
         backend, kwargs = design_types.Edb(version="2026.1")
@@ -92,7 +93,6 @@ def test_edb_defaults_to_grpc_for_2026_1_and_later(restore_settings_state, fake_
     assert kwargs["version"] == "2026.1"
     assert settings.specified_version == "2026.1"
     assert settings.is_grpc is True
-    assert settings.is_in_memory is True
 
 
 def test_edb_defaults_to_dotnet_before_2026_1(restore_settings_state, fake_backends):

--- a/tests/unit/test_grpc_in_memory.py
+++ b/tests/unit/test_grpc_in_memory.py
@@ -26,6 +26,8 @@ from pyedb.generic.settings import settings
 from pyedb.grpc import edb_init as edb_init_module, rpc_session as rpc_session_module
 from pyedb.grpc.edb_init import EdbInit
 from pyedb.grpc.rpc_session import RpcSession
+from tests.conftest import config
+import pytest
 
 
 def _reset_rpc_session_state():
@@ -37,7 +39,7 @@ def _reset_rpc_session_state():
     RpcSession.in_memory = False
     settings.is_in_memory = False
 
-
+@pytest.mark.skipif(not config["use_grpc"], reason="Applies only for grpc.")
 def test_rpc_session_falls_back_to_standard_rpc_when_in_memory_library_is_missing(monkeypatch):
     _reset_rpc_session_state()
     launched = {}
@@ -45,7 +47,6 @@ def test_rpc_session_falls_back_to_standard_rpc_when_in_memory_library_is_missin
     monkeypatch.setattr(rpc_session_module, "is_linux", False)
     monkeypatch.setattr(rpc_session_module, "env_path", lambda version: r"C:\\fake\\AnsysEM")
     monkeypatch.setattr(rpc_session_module, "start_managing", lambda *args, **kwargs: None)
-    monkeypatch.setattr(rpc_session_module, "is_in_memory", lambda: False)
 
     def fake_launch_session(base_path, port_num=None):
         launched["base_path"] = base_path
@@ -53,43 +54,14 @@ def test_rpc_session_falls_back_to_standard_rpc_when_in_memory_library_is_missin
         return SimpleNamespace(local_server_proc=SimpleNamespace(pid=4321), in_memory=False)
 
     monkeypatch.setattr(rpc_session_module, "launch_session", fake_launch_session)
-    RpcSession.in_memory = True
     RpcSession.start("2026.1", port=55001)
 
     assert launched == {"base_path": r"C:\\fake\\AnsysEM", "port_num": 55001}
     assert RpcSession.rpc_session is not None
     assert RpcSession.pid == 4321
     assert RpcSession.server_pid == 4321
-    assert RpcSession.in_memory is False
-    assert settings.is_in_memory is False
 
-
-def test_rpc_session_uses_launch_session_for_in_memory_transport(monkeypatch):
-    _reset_rpc_session_state()
-    launched = {}
-    session = SimpleNamespace(local_server_proc=SimpleNamespace(pid=0), in_memory=True)
-
-    monkeypatch.setattr(rpc_session_module, "is_linux", False)
-    monkeypatch.setattr(rpc_session_module, "env_path", lambda version: r"C:\\fake\\AnsysEM")
-    monkeypatch.setattr(rpc_session_module, "is_in_memory", lambda: True)
-
-    def fake_launch_session(base_path, port_num=None):
-        launched["base_path"] = base_path
-        launched["port_num"] = port_num
-        return session
-
-    monkeypatch.setattr(rpc_session_module, "launch_session", fake_launch_session)
-    RpcSession.in_memory = True
-    RpcSession.start("2026.1", port=55002)
-
-    assert launched == {"base_path": r"C:\\fake\\AnsysEM", "port_num": 55002}
-    assert RpcSession.rpc_session is session
-    assert RpcSession.pid == 0
-    assert RpcSession.server_pid == 0
-    assert RpcSession.in_memory is True
-    assert settings.is_in_memory is True
-
-
+@pytest.mark.skipif(not config["use_grpc"], reason="Applies only for grpc.")
 def test_edb_init_create_always_starts_rpc_session(monkeypatch):
     _reset_rpc_session_state()
     start_calls = []
@@ -97,7 +69,7 @@ def test_edb_init_create_always_starts_rpc_session(monkeypatch):
     created_db = object()
 
     def fake_start(edb_version, port=0, restart_server=False):
-        start_calls.append((edb_version, port, restart_server, RpcSession.in_memory))
+        start_calls.append((edb_version, port, restart_server))
         RpcSession.rpc_session = SimpleNamespace(in_memory=False)
 
     monkeypatch.setattr(RpcSession, "start", staticmethod(fake_start))
@@ -108,12 +80,10 @@ def test_edb_init_create_always_starts_rpc_session(monkeypatch):
     edb = EdbInit.__new__(EdbInit)
     edb.version = "2026.1"
     edb.logger = settings.logger
-    edb.in_memory = False
     edb._db = None
 
-    result = EdbInit._create(edb, "dummy.aedb", in_memory=False)
+    result = EdbInit._create(edb, "dummy.aedb")
 
     assert result is created_db
     assert created_paths == ["dummy.aedb"]
-    assert start_calls == [("2026.1", 0, False, False)]
-    assert settings.is_in_memory is False
+    assert start_calls == [("2026.1", 0, False)]

--- a/tests/unit/test_grpc_in_memory.py
+++ b/tests/unit/test_grpc_in_memory.py
@@ -22,12 +22,13 @@
 
 from types import SimpleNamespace
 
+import pytest
+
 from pyedb.generic.settings import settings
 from pyedb.grpc import edb_init as edb_init_module, rpc_session as rpc_session_module
 from pyedb.grpc.edb_init import EdbInit
 from pyedb.grpc.rpc_session import RpcSession
 from tests.conftest import config
-import pytest
 
 
 def _reset_rpc_session_state():
@@ -38,6 +39,7 @@ def _reset_rpc_session_state():
     RpcSession.server_pid = 0
     RpcSession.in_memory = False
     settings.is_in_memory = False
+
 
 @pytest.mark.skipif(not config["use_grpc"], reason="Applies only for grpc.")
 def test_rpc_session_falls_back_to_standard_rpc_when_in_memory_library_is_missing(monkeypatch):
@@ -60,6 +62,7 @@ def test_rpc_session_falls_back_to_standard_rpc_when_in_memory_library_is_missin
     assert RpcSession.rpc_session is not None
     assert RpcSession.pid == 4321
     assert RpcSession.server_pid == 4321
+
 
 @pytest.mark.skipif(not config["use_grpc"], reason="Applies only for grpc.")
 def test_edb_init_create_always_starts_rpc_session(monkeypatch):


### PR DESCRIPTION
This PR is fixing multiple EDB loading issue. When opening the second EDB, the RPC server were closed and reopened causing memory leakage and data mixing between multiple EDB's.

This PR is also adding EDB loading counter so when multiple EDB are open on same RPC session, when one EDB is clsoed without adding explicitly the flag terminate_rpc_session, the counter will be decremented and RPC server session will remains open until the last EDB is closed. This will prevent data losses. If Script execution fails the signal is still tigered and RPC server will be killed. 

This PR is also removing in_memory flag introduced recently but is not needed anyymore.

closes #2067 
closes #2068 