### PR TITLE
FIX: Refactor dotnet imports to avoid crash at Edb init

### DIFF
--- a/doc/changelog.d/2070.fixed.md
+++ b/doc/changelog.d/2070.fixed.md
@@ -1,0 +1,1 @@
+Refactor dotnet imports to avoid crash at Edb init

--- a/src/pyedb/dotnet/database/cell/primitive/primitive.py
+++ b/src/pyedb/dotnet/database/cell/primitive/primitive.py
@@ -20,8 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from System import String
-
 from pyedb.dotnet.database.cell.connectable import Connectable
 from pyedb.dotnet.database.general import convert_py_list_to_net_list
 from pyedb.dotnet.database.geometry.polygon_data import PolygonData
@@ -563,6 +561,8 @@ class Primitive(Connectable):
         str
             Name.
         """
+        from System import String
+
         val = String("")
 
         _, name = self._edb_object.GetProductProperty(self._pedb._edb.ProductId.Designer, 1, val)

--- a/src/pyedb/dotnet/database/sim_setup_data/data/mesh_operation.py
+++ b/src/pyedb/dotnet/database/sim_setup_data/data/mesh_operation.py
@@ -22,8 +22,6 @@
 
 from enum import Enum
 
-from System import Tuple
-
 from pyedb.dotnet.database.general import convert_py_list_to_net_list
 
 

--- a/src/pyedb/dotnet/database/sim_setup_data/data/mesh_operation.py
+++ b/src/pyedb/dotnet/database/sim_setup_data/data/mesh_operation.py
@@ -140,6 +140,8 @@ class MeshOperation(object):
 
     @nets_layers_list.setter
     def nets_layers_list(self, values):
+        from System import Tuple
+
         temp = []
         for net, layers in values.items():
             for layer in layers:

--- a/src/pyedb/dotnet/database/utilities/layer_utils.py
+++ b/src/pyedb/dotnet/database/utilities/layer_utils.py
@@ -20,8 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from System.Reflection import BindingFlags  # type: ignore
-
 
 def clear_is_owner(obj):
     """Use reflection to set the protected IsOwner property to False,
@@ -32,5 +30,7 @@ def clear_is_owner(obj):
     the native EDBLayer_Cleanup destructor from running on Python-owned wrappers
     and causing memory access violations during garbage collection.
     """
+    from System.Reflection import BindingFlags
+
     prop = obj.GetType().GetProperty("IsOwner", BindingFlags.NonPublic | BindingFlags.Instance)
     prop.SetValue(obj, False, None)

--- a/src/pyedb/grpc/edb.py
+++ b/src/pyedb/grpc/edb.py
@@ -85,7 +85,6 @@ if TYPE_CHECKING:
     from pyedb.grpc.database.layout.voltage_regulator import VoltageRegulator
     from pyedb.grpc.database.simulation_setup.siwave_dcir_simulation_setup import SIWaveDCIRSimulationSetup
     from pyedb.grpc.database.utility.layout_statistics import LayoutStatistics
-import warnings
 from zipfile import ZipFile as Zpf
 
 from ansys.edb.core.geometry.polygon_data import PolygonData as CorePolygonData


### PR DESCRIPTION
Atm pyaedt and other downstream application are facing an issue when using pyedb with dotnet as some import trigger access to `System` and the settings might not have been performed for this to work. The proposed changes hide the imports related to `System` inside the required functions. Below is the result of those changes on a linux VM without AEDT installed. The Runtime issue is expected but wasn't reachable previously.

```
PyEDB INFO: Star initializing Edb 12:29:46.892169
PyEDB INFO: Edb version 2025.2
CRITICAL - Uncaught exception
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.10/site-packages/pyedb/misc/decorators.py", line 144, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/pyedb/generic/design_types.py", line 407, in Edb
    return Edb(
  File "/usr/local/lib/python3.10/site-packages/pyedb/misc/decorators.py", line 156, in wrapper
    result = func(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/pyedb/dotnet/edb.py", line 241, in __init__
    self.__initialization()
  File "/usr/local/lib/python3.10/site-packages/pyedb/dotnet/edb.py", line 391, in __initialization
    raise RuntimeWarning("Failed to initialize Dlls.")
RuntimeWarning: Failed to initialize Dlls.
```

closes #2071 