### PR TITLE
CHORE: lib version updated

### DIFF
--- a/doc/changelog.d/2072.maintenance.md
+++ b/doc/changelog.d/2072.maintenance.md
@@ -1,0 +1,1 @@
+Lib version updated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ dependencies = [
     "numpy>=1.20.0,<3",
     "pydantic>=2.6.4,<2.14",
     "toml==0.10.2",
-    "ansys-edb-core==0.2.6",
-    "psutil",
+    "ansys-edb-core==0.3.1",
+    "psutil>=6.0.0",
     "defusedxml>=0.7,<8.0",
     "xmltodict"
 ]


### PR DESCRIPTION
This PR is updating ansys-edb-core version 0.3.1 and psutils like PyAEDT.