### PR TITLE
CI: Update pyaedt testing on release

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -571,12 +571,15 @@ jobs:
         with:
           max_attempts: 3
           retry_on: error
-          timeout_minutes: 40
+          timeout_minutes: 60
           command: |
             .venv\Scripts\Activate.ps1
             pytest -v external/pyaedt/tests/system/layout/test_3dlayout_edb.py
+            pytest -v external/pyaedt/tests/system/layout/test_3dlayout_modeler.py
             pytest -v external/pyaedt/tests/system/general/test_configuration_files.py
             pytest -v external/pyaedt/tests/system/general/test_circuit.py
+            pytest -v external/pyaedt/tests/system/general/test_hfss.py
+            pytest -v external/pyaedt/tests/system/general/test_primitives_3d.py
 
       - name: Run PyAEDT solvers tests
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
@@ -678,12 +681,15 @@ jobs:
         with:
           max_attempts: 3
           retry_on: error
-          timeout_minutes: 50
+          timeout_minutes: 60
           command: |
             . .venv/bin/activate
             pytest -v external/pyaedt/tests/system/layout/test_3dlayout_edb.py
+            pytest -v external/pyaedt/tests/system/layout/test_3dlayout_modeler.py
             pytest -v external/pyaedt/tests/system/general/test_configuration_files.py
             pytest -v external/pyaedt/tests/system/general/test_circuit.py
+            pytest -v external/pyaedt/tests/system/general/test_hfss.py
+            pytest -v external/pyaedt/tests/system/general/test_primitives_3d.py
 
       - name: Run PyAEDT solvers tests
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -585,6 +585,7 @@ jobs:
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         env:
           PYTHONMALLOC: malloc
+          PYAEDT_LOCAL_SETTINGS_PATH: 'external/pyaedt/tests/pyaedt_settings.yaml'
         with:
           max_attempts: 3
           retry_on: error
@@ -597,6 +598,7 @@ jobs:
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         env:
           PYTHONMALLOC: malloc
+          PYAEDT_LOCAL_SETTINGS_PATH: 'external/pyaedt/tests/pyaedt_settings.yaml'
         with:
           max_attempts: 3
           retry_on: error
@@ -678,6 +680,7 @@ jobs:
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         env:
           PYTHONMALLOC: malloc
+          PYAEDT_LOCAL_SETTINGS_PATH: 'external/pyaedt/tests/pyaedt_settings.yaml'
         with:
           max_attempts: 3
           retry_on: error
@@ -695,6 +698,7 @@ jobs:
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         env:
           PYTHONMALLOC: malloc
+          PYAEDT_LOCAL_SETTINGS_PATH: 'external/pyaedt/tests/pyaedt_settings.yaml'
         with:
           max_attempts: 3
           retry_on: error
@@ -707,6 +711,7 @@ jobs:
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         env:
           PYTHONMALLOC: malloc
+          PYAEDT_LOCAL_SETTINGS_PATH: 'external/pyaedt/tests/pyaedt_settings.yaml'
         with:
           max_attempts: 3
           retry_on: error

--- a/doc/changelog.d/2079.maintenance.md
+++ b/doc/changelog.d/2079.maintenance.md
@@ -1,0 +1,1 @@
+Update pyaedt testing on release


### PR DESCRIPTION
Update the release process to catch missing test files and also align test configuration with what pyaedt is currently using when testing.