### PR TITLE
CHORE: Bump dev version into v0.75.dev0

### DIFF
--- a/doc/changelog.d/2094.maintenance.md
+++ b/doc/changelog.d/2094.maintenance.md
@@ -1,0 +1,1 @@
+Bump dev version into v0.75.dev0

--- a/src/pyedb/__init__.py
+++ b/src/pyedb/__init__.py
@@ -59,7 +59,7 @@ deprecation_warning()
 #
 
 pyedb_path = os.path.dirname(__file__)
-__version__ = "0.74.dev0"
+__version__ = "0.75.dev0"
 version = __version__
 
 #


### PR DESCRIPTION
As title says, follows release of `0.74.0`