### PR TITLE
FIX: Rpc session fix

### DIFF
--- a/doc/changelog.d/2107.fixed.md
+++ b/doc/changelog.d/2107.fixed.md
@@ -1,0 +1,1 @@
+Rpc session fix

--- a/src/pyedb/grpc/database/padstacks.py
+++ b/src/pyedb/grpc/database/padstacks.py
@@ -208,9 +208,11 @@ class Padstacks(object):
         self.__definitions = {}
         for padstack_def in self._pedb.db.padstack_defs:
             try:
+                if padstack_def.is_null:
+                    continue
                 self.__definitions[padstack_def.name] = PadstackDef(self._pedb, padstack_def)
             except (Exception, InvalidArgumentException) as e:
-                self._logger.warning(f"Error processing padstack definition {padstack_def.name}: {e}")
+                self._logger.warning(f"Error processing padstack definition: {e}")
         return self.__definitions
 
     @property

--- a/src/pyedb/grpc/edb_init.py
+++ b/src/pyedb/grpc/edb_init.py
@@ -193,20 +193,19 @@ class EdbInit(object):
         else:
             return False
 
-    def close(self, terminate_rpc_session=None, keep_session_alive=False):
+    def close(self, terminate_rpc_session=None):
         """Close the database.
 
         Parameters
         ----------
         terminate_rpc_session : bool, optional
-            Deprecated.  Use ``keep_session_alive`` instead.
             When ``True``, forcibly terminate the RPC server regardless of how
             many other databases are still open.
-        keep_session_alive : bool, optional
-            When ``True``, the RPC server is kept running after the database is
-            closed so that subsequent ``Edb`` instances can reuse it.
-            When ``False`` (the default), the server is automatically shut down
-            once the last open database is closed.
+            When ``False``, the RPC server is kept running after the database is
+            closed so that subsequent ``Edb`` instances can reuse it without a
+            server restart.
+            When not specified (the default), the server is automatically shut
+            down once the last open database is closed.
 
         Notes
         -----
@@ -216,14 +215,13 @@ class EdbInit(object):
         self._db.close()
         self._db = None
         if terminate_rpc_session is True:
-            # Legacy explicit flag — force-kill regardless of ref count
+            # Force-kill regardless of ref count
             RpcSession.close()
-        elif keep_session_alive or terminate_rpc_session is False:
-            # User explicitly asked to keep the server running
+        elif terminate_rpc_session is False:
+            # Explicitly keep the server running
             RpcSession.release()
         else:
-            # Default (terminate_rpc_session=None, keep_session_alive=False):
-            # release and shut down if this was the last DB
+            # Default: release and shut down if this was the last DB
             if RpcSession.release():
                 RpcSession.close()
         self._clean_variables()

--- a/src/pyedb/grpc/edb_init.py
+++ b/src/pyedb/grpc/edb_init.py
@@ -193,27 +193,39 @@ class EdbInit(object):
         else:
             return False
 
-    def close(self, terminate_rpc_session=False):
+    def close(self, terminate_rpc_session=None, keep_session_alive=False):
         """Close the database.
 
         Parameters
         ----------
         terminate_rpc_session : bool, optional
-            Force termination of the RPC session regardless of how many other databases are still
-            open. The default is ``False``, meaning the RPC server is only shut down automatically
-            when the **last** open database is closed (reference-counted).
+            Deprecated.  Use ``keep_session_alive`` instead.
+            When ``True``, forcibly terminate the RPC server regardless of how
+            many other databases are still open.
+        keep_session_alive : bool, optional
+            When ``True``, the RPC server is kept running after the database is
+            closed so that subsequent ``Edb`` instances can reuse it.
+            When ``False`` (the default), the server is automatically shut down
+            once the last open database is closed.
 
         Notes
         -----
-        Unsaved changes will be lost. When ``terminate_rpc_session=True`` and multiple databases
-        are open, all connections will be lost immediately.
+        Unsaved changes will be lost.  Forcibly terminating the server while
+        other databases are still open will break those connections immediately.
         """
         self._db.close()
         self._db = None
-        if terminate_rpc_session:
+        if terminate_rpc_session is True:
+            # Legacy explicit flag — force-kill regardless of ref count
             RpcSession.close()
-        else:
+        elif keep_session_alive or terminate_rpc_session is False:
+            # User explicitly asked to keep the server running
             RpcSession.release()
+        else:
+            # Default (terminate_rpc_session=None, keep_session_alive=False):
+            # release and shut down if this was the last DB
+            if RpcSession.release():
+                RpcSession.close()
         self._clean_variables()
         return True
 

--- a/src/pyedb/grpc/edb_init.py
+++ b/src/pyedb/grpc/edb_init.py
@@ -178,6 +178,7 @@ class EdbInit(object):
         -------
         object or None
             The return value of ``func``, or ``None`` if all attempts fail.
+
         """
         for attempt in range(max_attempts):
             try:

--- a/src/pyedb/grpc/edb_init.py
+++ b/src/pyedb/grpc/edb_init.py
@@ -263,8 +263,8 @@ class EdbInit(object):
         if self._db is not None:
             try:
                 self._db.close()
-            except Exception:
-                pass
+            except Exception as e:  # nosec B110
+                self.logger.debug(f"Database close() raised: {e}")
             self._db = None
         if terminate_rpc_session is True:
             # Force-kill regardless of ref count

--- a/src/pyedb/grpc/edb_init.py
+++ b/src/pyedb/grpc/edb_init.py
@@ -212,8 +212,12 @@ class EdbInit(object):
         Unsaved changes will be lost.  Forcibly terminating the server while
         other databases are still open will break those connections immediately.
         """
-        self._db.close()
-        self._db = None
+        if self._db is not None:
+            try:
+                self._db.close()
+            except Exception:
+                pass
+            self._db = None
         if terminate_rpc_session is True:
             # Force-kill regardless of ref count
             RpcSession.close()

--- a/src/pyedb/grpc/edb_init.py
+++ b/src/pyedb/grpc/edb_init.py
@@ -119,7 +119,7 @@ class EdbInit(object):
         if not RpcSession.rpc_session:
             self.logger.error("Failed to start RPC server.")
             return False
-        self._db = database.Database.create(db_path)
+        self._db = self._grpc_retry(database.Database.create, db_path)
         if self._db:
             RpcSession.acquire()
         return self._db
@@ -151,10 +151,58 @@ class EdbInit(object):
         if not RpcSession.rpc_session:
             self.logger.error("Failed to start RPC server.")
             return False
-        self._db = database.Database.open(db_path, read_only)
+        self._db = self._grpc_retry(database.Database.open, db_path, read_only)
         if self._db:
             RpcSession.acquire()
         return self._db
+
+    def _grpc_retry(self, func, *args, max_attempts=3, delay=1.0):
+        """Call a gRPC database function with retries on transient failures.
+
+        The RPC server may still be processing a previous close operation when the
+        next open/create call arrives, causing transient gRPC errors. This method
+        retries with a short delay to handle that race condition.
+
+        Parameters
+        ----------
+        func : callable
+            The database function to call (e.g. ``database.Database.open``).
+        *args :
+            Positional arguments forwarded to ``func``.
+        max_attempts : int, optional
+            Maximum number of attempts. The default is ``3``.
+        delay : float, optional
+            Seconds to wait between retries. The default is ``1.0``.
+
+        Returns
+        -------
+        object or None
+            The return value of ``func``, or ``None`` if all attempts fail.
+        """
+        last_exception = None
+        for attempt in range(max_attempts):
+            try:
+                result = func(*args)
+                if result is not None:
+                    return result
+                # func returned None — treat as transient failure
+                if attempt < max_attempts - 1:
+                    self.logger.warning(
+                        f"gRPC call {func.__name__} returned None (attempt {attempt + 1}/{max_attempts}). "
+                        f"Retrying in {delay}s..."
+                    )
+                    time.sleep(delay)
+            except Exception as e:
+                last_exception = e
+                if attempt < max_attempts - 1:
+                    self.logger.warning(
+                        f"gRPC call {func.__name__} failed (attempt {attempt + 1}/{max_attempts}): {e}. "
+                        f"Retrying in {delay}s..."
+                    )
+                    time.sleep(delay)
+                else:
+                    self.logger.error(f"gRPC call {func.__name__} failed after {max_attempts} attempts: {e}")
+        return None
 
     def delete(self, db_path):
         """Delete a database at the specified file location.

--- a/src/pyedb/grpc/edb_init.py
+++ b/src/pyedb/grpc/edb_init.py
@@ -157,7 +157,8 @@ class EdbInit(object):
         return self._db
 
     def _grpc_retry(self, func, *args, max_attempts=3, delay=1.0):
-        """Call a gRPC database function with retries on transient failures.
+        """
+        Call a gRPC database function with retries on transient failures.
 
         The RPC server may still be processing a previous close operation when the
         next open/create call arrives, causing transient gRPC errors. This method

--- a/src/pyedb/grpc/edb_init.py
+++ b/src/pyedb/grpc/edb_init.py
@@ -179,7 +179,6 @@ class EdbInit(object):
         object or None
             The return value of ``func``, or ``None`` if all attempts fail.
         """
-        last_exception = None
         for attempt in range(max_attempts):
             try:
                 result = func(*args)
@@ -193,7 +192,6 @@ class EdbInit(object):
                     )
                     time.sleep(delay)
             except Exception as e:
-                last_exception = e
                 if attempt < max_attempts - 1:
                     self.logger.warning(
                         f"gRPC call {func.__name__} failed (attempt {attempt + 1}/{max_attempts}): {e}. "

--- a/src/pyedb/grpc/rpc_session.py
+++ b/src/pyedb/grpc/rpc_session.py
@@ -255,11 +255,6 @@ class RpcSession:
 
     @staticmethod
     def _wait_for_process_exit(proc, timeout=10.0):
-        """Wait until the server process has fully exited.
-
-        This ensures the port is released before the next session starts.
-        Falls back to a fixed delay if the process object is unavailable.
-        """
         if proc is None:
             time.sleep(1.0)
             return
@@ -288,13 +283,6 @@ class RpcSession:
 
     @staticmethod
     def _is_server_alive():
-        """Check whether the RPC server process is still running.
-
-        Returns
-        -------
-        bool
-            ``True`` if the server process exists and is alive, ``False`` otherwise.
-        """
         if not RpcSession.rpc_session:
             return False
         try:

--- a/src/pyedb/grpc/rpc_session.py
+++ b/src/pyedb/grpc/rpc_session.py
@@ -173,7 +173,25 @@ class RpcSession:
     @staticmethod
     def __start_rpc_server():
         preexisting = _SESSION_MOD.current_session is not None
-        RpcSession.rpc_session = launch_session(RpcSession.base_path, port_num=RpcSession.port)
+        max_attempts = 3 if _IS_WINDOWS else 1
+        last_exc = None
+        for attempt in range(max_attempts):
+            try:
+                RpcSession.rpc_session = launch_session(RpcSession.base_path, port_num=RpcSession.port)
+                break
+            except Exception as e:
+                last_exc = e
+                settings.logger.warning(
+                    f"launch_session attempt {attempt + 1}/{max_attempts} failed: {e}"
+                )
+                if attempt < max_attempts - 1:
+                    # Pick a new random port and retry
+                    RpcSession.port = RpcSession.__get_random_free_port()
+                    time.sleep(2.0)
+                else:
+                    settings.logger.error("All launch_session attempts failed.")
+                    RpcSession.rpc_session = None
+                    return
         RpcSession._owns_session = not preexisting
         start_managing(IOMangementType.READ_AND_WRITE)
         time.sleep(latency_delay)
@@ -222,6 +240,11 @@ class RpcSession:
         If not executed, users should force restarting the process using the flag `restart_server`=`True`.
         """
         if RpcSession.rpc_session:
+            server_proc = None
+            try:
+                server_proc = RpcSession.rpc_session.local_server_proc
+            except Exception:
+                pass
             try:
                 end_managing()
             except Exception:
@@ -231,12 +254,39 @@ class RpcSession:
             except Exception:
                 pass
             # On Windows, socket/process cleanup can be slow (TIME_WAIT state).
-            # Allow extra time before the next server can bind a port.
+            # Wait for the server process to fully terminate before proceeding.
             if _IS_WINDOWS:
-                time.sleep(1.0)
+                RpcSession._wait_for_process_exit(server_proc, timeout=10.0)
             else:
                 time.sleep(latency_delay)
         RpcSession._reset_session_state()
+
+    @staticmethod
+    def _wait_for_process_exit(proc, timeout=10.0):
+        """Wait until the server process has fully exited (Windows only).
+
+        Falls back to a fixed delay if the process object is unavailable.
+        """
+        if proc is None:
+            time.sleep(2.0)
+            return
+        try:
+            pid = proc.pid if hasattr(proc, "pid") else None
+            if pid is None:
+                time.sleep(2.0)
+                return
+            p = psutil.Process(pid)
+            p.wait(timeout=timeout)
+        except psutil.NoSuchProcess:
+            # Already gone
+            pass
+        except psutil.TimeoutExpired:
+            settings.logger.warning(
+                f"RPC server process {pid} did not exit within {timeout}s. "
+                "Proceeding anyway — next launch may fail."
+            )
+        except Exception:
+            time.sleep(2.0)
 
     @staticmethod
     def _is_server_alive():

--- a/src/pyedb/grpc/rpc_session.py
+++ b/src/pyedb/grpc/rpc_session.py
@@ -174,13 +174,11 @@ class RpcSession:
     def __start_rpc_server():
         preexisting = _SESSION_MOD.current_session is not None
         max_attempts = 3 if _IS_WINDOWS else 1
-        last_exc = None
         for attempt in range(max_attempts):
             try:
                 RpcSession.rpc_session = launch_session(RpcSession.base_path, port_num=RpcSession.port)
                 break
             except Exception as e:
-                last_exc = e
                 settings.logger.warning(f"launch_session attempt {attempt + 1}/{max_attempts} failed: {e}")
                 if attempt < max_attempts - 1:
                     # Pick a new random port and retry
@@ -188,8 +186,7 @@ class RpcSession:
                     time.sleep(2.0)
                 else:
                     settings.logger.error("All launch_session attempts failed.")
-                    RpcSession.rpc_session = None
-                    return
+                    raise
         RpcSession._owns_session = not preexisting
         start_managing(IOMangementType.READ_AND_WRITE)
         time.sleep(latency_delay)
@@ -251,12 +248,12 @@ class RpcSession:
                 RpcSession.rpc_session.disconnect()
             except Exception:
                 pass
-            # On Windows, socket/process cleanup can be slow (TIME_WAIT state).
             # Wait for the server process to fully terminate before proceeding.
+            # Windows sockets are slower to release (TIME_WAIT state).
             if _IS_WINDOWS:
                 RpcSession._wait_for_process_exit(server_proc, timeout=10.0)
             else:
-                time.sleep(latency_delay)
+                RpcSession._wait_for_process_exit(server_proc, timeout=5.0)
         RpcSession._reset_session_state()
 
     @staticmethod

--- a/src/pyedb/grpc/rpc_session.py
+++ b/src/pyedb/grpc/rpc_session.py
@@ -277,10 +277,7 @@ class RpcSession:
             # Already gone
             pass
         except psutil.TimeoutExpired:
-            settings.logger.warning(
-                f"RPC server process {pid} did not exit within {timeout}s. "
-                f"Attempting to kill it."
-            )
+            settings.logger.warning(f"RPC server process {pid} did not exit within {timeout}s. Attempting to kill it.")
             try:
                 p.kill()
                 p.wait(timeout=3.0)

--- a/src/pyedb/grpc/rpc_session.py
+++ b/src/pyedb/grpc/rpc_session.py
@@ -25,7 +25,7 @@ import secrets
 import sys
 import time
 
-from ansys.edb.core.session import launch_session
+from ansys.edb.core.session import MOD as _SESSION_MOD, launch_session
 from ansys.edb.core.utility.io_manager import (
     IOMangementType,
     end_managing,
@@ -50,6 +50,7 @@ class RpcSession:
     port = 10000
     server_pid = 0
     _open_db_count = 0  # number of EDB databases currently open against this server
+    _owns_session = False  # True only when RpcSession launched the server itself
 
     @staticmethod
     def acquire():
@@ -77,8 +78,16 @@ class RpcSession:
             RpcSession._open_db_count -= 1
         settings.logger.info(f"RPC session released (open databases: {RpcSession._open_db_count})")
         if RpcSession._open_db_count == 0:
-            RpcSession.close()
-            return True
+            if RpcSession._owns_session:
+                RpcSession.close()
+                return True
+            else:
+                settings.logger.info(
+                    "RPC session was not started by RpcSession; skipping shutdown."
+                )
+                RpcSession.rpc_session = None
+                RpcSession._open_db_count = 0
+                return False
         return False
 
     @staticmethod
@@ -162,12 +171,17 @@ class RpcSession:
 
     @staticmethod
     def __start_rpc_server():
+        preexisting = _SESSION_MOD.current_session is not None
         RpcSession.rpc_session = launch_session(RpcSession.base_path, port_num=RpcSession.port)
+        RpcSession._owns_session = not preexisting
         start_managing(IOMangementType.READ_AND_WRITE)
         time.sleep(latency_delay)
         if RpcSession.rpc_session:
             RpcSession.pid = RpcSession.rpc_session.local_server_proc.pid
-            settings.logger.logger.info("Grpc session started")
+            if preexisting:
+                settings.logger.info("Attached to preexisting gRPC session (not owned by RpcSession)")
+            else:
+                settings.logger.logger.info("Grpc session started")
 
     @staticmethod
     def kill():
@@ -214,6 +228,7 @@ class RpcSession:
         RpcSession.pid = 0
         RpcSession.server_pid = 0
         RpcSession._open_db_count = 0
+        RpcSession._owns_session = False
 
     @staticmethod
     def __get_random_free_port():

--- a/src/pyedb/grpc/rpc_session.py
+++ b/src/pyedb/grpc/rpc_session.py
@@ -82,9 +82,7 @@ class RpcSession:
                 RpcSession.close()
                 return True
             else:
-                settings.logger.info(
-                    "RPC session was not started by RpcSession; skipping shutdown."
-                )
+                settings.logger.info("RPC session was not started by RpcSession; skipping shutdown.")
                 RpcSession.rpc_session = None
                 RpcSession._open_db_count = 0
                 return False

--- a/src/pyedb/grpc/rpc_session.py
+++ b/src/pyedb/grpc/rpc_session.py
@@ -295,7 +295,8 @@ class RpcSession:
 
     @staticmethod
     def _reset_session_state():
-        """Reset all session state to initial values.
+        """
+        Reset all session state to initial values.
 
         Clears the session reference, PIDs, ref count, and the underlying
         ``ansys.edb.core.session`` module's ``current_session`` to prevent

--- a/src/pyedb/grpc/rpc_session.py
+++ b/src/pyedb/grpc/rpc_session.py
@@ -65,30 +65,24 @@ class RpcSession:
     @staticmethod
     def release():
         """
-        Decrement the open-database reference counter and shut down the server when it reaches zero.
+        Decrement the open-database reference counter.
+
+        The RPC server is **not** shut down when the counter reaches zero.
+        Use :meth:`close` (or pass ``terminate_rpc_session=True`` to the EDB
+        ``close`` method) to explicitly terminate the server.  For standalone
+        scripts the ``atexit`` handler registered by :class:`EdbInit` ensures
+        the server process is cleaned up on interpreter exit.
 
         Returns
         -------
         bool
-            ``True`` if the RPC session was terminated (last database closed),
-            ``False`` if other databases are still open and the session was kept alive.
-
+            ``True`` when the counter has reached zero (no more open databases),
+            ``False`` otherwise.
         """
         if RpcSession._open_db_count > 0:
             RpcSession._open_db_count -= 1
         settings.logger.info(f"RPC session released (open databases: {RpcSession._open_db_count})")
-        if RpcSession._open_db_count == 0:
-            if RpcSession._owns_session:
-                RpcSession.close()
-                return True
-            else:
-                settings.logger.info(
-                    "RPC session was not started by RpcSession; skipping shutdown."
-                )
-                RpcSession.rpc_session = None
-                RpcSession._open_db_count = 0
-                return False
-        return False
+        return RpcSession._open_db_count == 0
 
     @staticmethod
     def start(edb_version, port=0, restart_server=False):

--- a/src/pyedb/grpc/rpc_session.py
+++ b/src/pyedb/grpc/rpc_session.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 import os
+import platform
 import secrets
 import sys
 import time
@@ -36,8 +37,9 @@ import psutil
 from pyedb import __version__
 from pyedb.generic.general_methods import env_path, env_value, is_linux
 from pyedb.generic.settings import settings
-from pyedb.misc.misc import list_installed_ansysem
 
+latency_delay = 0.1
+_IS_WINDOWS = platform.system() == "Windows"
 latency_delay = 0.1
 
 
@@ -140,7 +142,12 @@ class RpcSession:
         os.environ["PATH"] = os.pathsep.join([os.environ["PATH"], RpcSession.base_path])
 
         if RpcSession.rpc_session:
-            if restart_server:
+            # Validate the existing session is still alive
+            if not RpcSession._is_server_alive():
+                settings.logger.warning("RPC server process is no longer alive. Cleaning up stale session.")
+                RpcSession._reset_session_state()
+                RpcSession.__start_rpc_server()
+            elif restart_server:
                 settings.logger.info("Restarting RPC server.")
                 RpcSession.close()
                 RpcSession.__start_rpc_server()
@@ -215,14 +222,60 @@ class RpcSession:
         If not executed, users should force restarting the process using the flag `restart_server`=`True`.
         """
         if RpcSession.rpc_session:
-            end_managing()
-            RpcSession.rpc_session.disconnect()
-            time.sleep(latency_delay)
-            RpcSession.rpc_session = None
+            try:
+                end_managing()
+            except Exception:
+                pass
+            try:
+                RpcSession.rpc_session.disconnect()
+            except Exception:
+                pass
+            # On Windows, socket/process cleanup can be slow (TIME_WAIT state).
+            # Allow extra time before the next server can bind a port.
+            if _IS_WINDOWS:
+                time.sleep(1.0)
+            else:
+                time.sleep(latency_delay)
+        RpcSession._reset_session_state()
+
+    @staticmethod
+    def _is_server_alive():
+        """Check whether the RPC server process is still running.
+
+        Returns
+        -------
+        bool
+            ``True`` if the server process exists and is alive, ``False`` otherwise.
+        """
+        if not RpcSession.rpc_session:
+            return False
+        try:
+            proc = RpcSession.rpc_session.local_server_proc
+            if proc is None:
+                return False
+            return psutil.pid_exists(proc.pid) and proc.poll() is None
+        except Exception:
+            return False
+
+    @staticmethod
+    def _reset_session_state():
+        """Reset all session state to initial values.
+
+        Clears the session reference, PIDs, ref count, and the underlying
+        ``ansys.edb.core.session`` module's ``current_session`` to prevent
+        ``__start_rpc_server`` from falsely detecting a preexisting session.
+        """
+        RpcSession.rpc_session = None
         RpcSession.pid = 0
         RpcSession.server_pid = 0
         RpcSession._open_db_count = 0
         RpcSession._owns_session = False
+        # Clear the global session reference so the next launch_session()
+        # call does not attach to a dead session.
+        try:
+            _SESSION_MOD.current_session = None
+        except Exception:
+            pass
 
     @staticmethod
     def __get_random_free_port():

--- a/src/pyedb/grpc/rpc_session.py
+++ b/src/pyedb/grpc/rpc_session.py
@@ -238,16 +238,16 @@ class RpcSession:
             server_proc = None
             try:
                 server_proc = RpcSession.rpc_session.local_server_proc
-            except Exception:
-                pass
+            except Exception as e:  # nosec B110
+                settings.logger.debug(f"Could not retrieve server process handle: {e}")
             try:
                 end_managing()
-            except Exception:
-                pass
+            except Exception as e:  # nosec B110
+                settings.logger.debug(f"end_managing() raised during close: {e}")
             try:
                 RpcSession.rpc_session.disconnect()
-            except Exception:
-                pass
+            except Exception as e:  # nosec B110
+                settings.logger.debug(f"disconnect() raised during close: {e}")
             # Wait for the server process to fully exit so the port is released
             # before the next session starts.
             RpcSession._wait_for_process_exit(server_proc, timeout=10.0)
@@ -284,8 +284,8 @@ class RpcSession:
             try:
                 p.kill()
                 p.wait(timeout=3.0)
-            except Exception:
-                pass
+            except Exception as e:  # nosec B110
+                settings.logger.debug(f"Failed to force-kill RPC server process {pid}: {e}")
         except Exception:
             time.sleep(1.0)
 
@@ -325,8 +325,8 @@ class RpcSession:
         # call does not attach to a dead session.
         try:
             _SESSION_MOD.current_session = None
-        except Exception:
-            pass
+        except Exception as e:  # nosec B110
+            settings.logger.debug(f"Could not clear current_session: {e}")
 
     @staticmethod
     def __get_random_free_port():

--- a/src/pyedb/grpc/rpc_session.py
+++ b/src/pyedb/grpc/rpc_session.py
@@ -248,39 +248,46 @@ class RpcSession:
                 RpcSession.rpc_session.disconnect()
             except Exception:
                 pass
-            # Wait for the server process to fully terminate before proceeding.
-            # Windows sockets are slower to release (TIME_WAIT state).
-            if _IS_WINDOWS:
-                RpcSession._wait_for_process_exit(server_proc, timeout=10.0)
-            else:
-                RpcSession._wait_for_process_exit(server_proc, timeout=5.0)
+            # Wait for the server process to fully exit so the port is released
+            # before the next session starts.
+            RpcSession._wait_for_process_exit(server_proc, timeout=10.0)
         RpcSession._reset_session_state()
 
     @staticmethod
     def _wait_for_process_exit(proc, timeout=10.0):
-        """Wait until the server process has fully exited (Windows only).
+        """Wait until the server process has fully exited.
 
+        This ensures the port is released before the next session starts.
         Falls back to a fixed delay if the process object is unavailable.
         """
         if proc is None:
-            time.sleep(2.0)
+            time.sleep(1.0)
             return
         try:
             pid = proc.pid if hasattr(proc, "pid") else None
             if pid is None:
-                time.sleep(2.0)
+                time.sleep(1.0)
                 return
             p = psutil.Process(pid)
             p.wait(timeout=timeout)
+            # Additional delay on Windows for socket TIME_WAIT
+            if _IS_WINDOWS:
+                time.sleep(0.5)
         except psutil.NoSuchProcess:
             # Already gone
             pass
         except psutil.TimeoutExpired:
             settings.logger.warning(
-                f"RPC server process {pid} did not exit within {timeout}s. Proceeding anyway — next launch may fail."
+                f"RPC server process {pid} did not exit within {timeout}s. "
+                f"Attempting to kill it."
             )
+            try:
+                p.kill()
+                p.wait(timeout=3.0)
+            except Exception:
+                pass
         except Exception:
-            time.sleep(2.0)
+            time.sleep(1.0)
 
     @staticmethod
     def _is_server_alive():

--- a/src/pyedb/grpc/rpc_session.py
+++ b/src/pyedb/grpc/rpc_session.py
@@ -181,9 +181,7 @@ class RpcSession:
                 break
             except Exception as e:
                 last_exc = e
-                settings.logger.warning(
-                    f"launch_session attempt {attempt + 1}/{max_attempts} failed: {e}"
-                )
+                settings.logger.warning(f"launch_session attempt {attempt + 1}/{max_attempts} failed: {e}")
                 if attempt < max_attempts - 1:
                     # Pick a new random port and retry
                     RpcSession.port = RpcSession.__get_random_free_port()
@@ -282,8 +280,7 @@ class RpcSession:
             pass
         except psutil.TimeoutExpired:
             settings.logger.warning(
-                f"RPC server process {pid} did not exit within {timeout}s. "
-                "Proceeding anyway — next launch may fail."
+                f"RPC server process {pid} did not exit within {timeout}s. Proceeding anyway — next launch may fail."
             )
         except Exception:
             time.sleep(2.0)

--- a/tests/system/base_test_class.py
+++ b/tests/system/base_test_class.py
@@ -30,9 +30,8 @@ pytestmark = [pytest.mark.unit, pytest.mark.legacy]
 
 @pytest.mark.usefixtures("close_rpc_session")
 class BaseTestClass:
-    @classmethod
     @pytest.fixture(scope="class", autouse=True)
-    def setup_class(cls, request, get_edb_examples):
+    def setup_class(self, request, get_edb_examples):
         # Set up the EDB app once per class
         # Finalizer to close the EDB app after all tests
         yield

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -22,7 +22,6 @@
 
 """Test configuration for system tests."""
 
-
 import pytest
 
 from pyedb.grpc.rpc_session import RpcSession

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -34,3 +34,5 @@ def close_rpc_session(init_scratch):
     yield
     if GRPC:
         RpcSession.close()
+        # Force a fresh port for the next class to avoid TIME_WAIT conflicts
+        RpcSession.port = 0

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -22,20 +22,16 @@
 
 """Test configuration for system tests."""
 
-from pathlib import Path
 
 import pytest
 
-from pyedb.generic.design_types import Edb
-from tests.conftest import GRPC, Scratch, desktop_version, generate_random_string
+from pyedb.grpc.rpc_session import RpcSession
+from tests.conftest import GRPC
 
 
 @pytest.fixture(scope="class", autouse=True)
 def close_rpc_session(init_scratch):
-    """Provide a module-scoped scratch directory."""
+    """Ensure the RPC server is shut down after each test class."""
     yield
     if GRPC:
-        scratch = Scratch(init_scratch)
-        sub_folder = Path(scratch.path) / generate_random_string(6) / ".aedb"
-        dummy_edb = Edb(str(sub_folder), version=desktop_version, grpc=True)
-        dummy_edb.close(terminate_rpc_session=True)
+        RpcSession.close()

--- a/tests/unit/test_grpc_in_memory.py
+++ b/tests/unit/test_grpc_in_memory.py
@@ -38,6 +38,8 @@ def _reset_rpc_session_state():
     RpcSession.port = 10000
     RpcSession.server_pid = 0
     RpcSession.in_memory = False
+    RpcSession._open_db_count = 0
+    RpcSession._owns_session = False
     settings.is_in_memory = False
 
 
@@ -90,3 +92,187 @@ def test_edb_init_create_always_starts_rpc_session(monkeypatch):
     assert result is created_db
     assert created_paths == ["dummy.aedb"]
     assert start_calls == [("2026.1", 0, False)]
+
+
+@pytest.mark.skipif(not config["use_grpc"], reason="Applies only for grpc.")
+def test_acquire_increments_open_db_count():
+    _reset_rpc_session_state()
+    assert RpcSession._open_db_count == 0
+    RpcSession.acquire()
+    assert RpcSession._open_db_count == 1
+    RpcSession.acquire()
+    assert RpcSession._open_db_count == 2
+
+
+@pytest.mark.skipif(not config["use_grpc"], reason="Applies only for grpc.")
+def test_release_decrements_open_db_count():
+    _reset_rpc_session_state()
+    RpcSession.acquire()
+    RpcSession.acquire()
+    assert RpcSession._open_db_count == 2
+    result = RpcSession.release()
+    assert result is False
+    assert RpcSession._open_db_count == 1
+
+
+@pytest.mark.skipif(not config["use_grpc"], reason="Applies only for grpc.")
+def test_release_does_not_go_below_zero():
+    _reset_rpc_session_state()
+    RpcSession.release()
+    assert RpcSession._open_db_count == 0
+
+
+@pytest.mark.skipif(not config["use_grpc"], reason="Applies only for grpc.")
+def test_release_closes_session_when_owned_and_count_reaches_zero(monkeypatch):
+    _reset_rpc_session_state()
+    close_called = []
+    monkeypatch.setattr(RpcSession, "close", staticmethod(lambda: close_called.append(True)))
+
+    RpcSession._owns_session = True
+    RpcSession.rpc_session = SimpleNamespace(in_memory=False)
+    RpcSession.acquire()
+    result = RpcSession.release()
+
+    assert result is True
+    assert len(close_called) == 1
+
+
+@pytest.mark.skipif(not config["use_grpc"], reason="Applies only for grpc.")
+def test_release_does_not_close_session_when_not_owned(monkeypatch):
+    _reset_rpc_session_state()
+    close_called = []
+    monkeypatch.setattr(RpcSession, "close", staticmethod(lambda: close_called.append(True)))
+
+    RpcSession._owns_session = False
+    RpcSession.rpc_session = SimpleNamespace(in_memory=False)
+    RpcSession.acquire()
+    result = RpcSession.release()
+
+    assert result is False
+    assert len(close_called) == 0
+    assert RpcSession.rpc_session is None
+
+
+@pytest.mark.skipif(not config["use_grpc"], reason="Applies only for grpc.")
+def test_start_sets_owns_session_true_when_no_preexisting_session(monkeypatch):
+    _reset_rpc_session_state()
+
+    monkeypatch.setattr(rpc_session_module, "is_linux", False)
+    monkeypatch.setattr(rpc_session_module, "env_path", lambda version: r"C:\\fake\\AnsysEM")
+    monkeypatch.setattr(rpc_session_module, "start_managing", lambda *args, **kwargs: None)
+    monkeypatch.setattr(rpc_session_module, "_SESSION_MOD", SimpleNamespace(current_session=None))
+
+    def fake_launch_session(base_path, port_num=None):
+        return SimpleNamespace(local_server_proc=SimpleNamespace(pid=1111), in_memory=False)
+
+    monkeypatch.setattr(rpc_session_module, "launch_session", fake_launch_session)
+    RpcSession.start("2026.1", port=55010)
+
+    assert RpcSession._owns_session is True
+    assert RpcSession.rpc_session is not None
+
+
+@pytest.mark.skipif(not config["use_grpc"], reason="Applies only for grpc.")
+def test_start_sets_owns_session_false_when_preexisting_session(monkeypatch):
+    _reset_rpc_session_state()
+
+    monkeypatch.setattr(rpc_session_module, "is_linux", False)
+    monkeypatch.setattr(rpc_session_module, "env_path", lambda version: r"C:\\fake\\AnsysEM")
+    monkeypatch.setattr(rpc_session_module, "start_managing", lambda *args, **kwargs: None)
+
+    preexisting = SimpleNamespace(port_num=55020)
+    monkeypatch.setattr(rpc_session_module, "_SESSION_MOD", SimpleNamespace(current_session=preexisting))
+
+    def fake_launch_session(base_path, port_num=None):
+        return SimpleNamespace(local_server_proc=SimpleNamespace(pid=2222), in_memory=False)
+
+    monkeypatch.setattr(rpc_session_module, "launch_session", fake_launch_session)
+    RpcSession.start("2026.1", port=55020)
+
+    assert RpcSession._owns_session is False
+    assert RpcSession.rpc_session is not None
+    assert RpcSession.pid == 2222
+
+
+@pytest.mark.skipif(not config["use_grpc"], reason="Applies only for grpc.")
+def test_close_resets_owns_session(monkeypatch):
+    _reset_rpc_session_state()
+    monkeypatch.setattr(rpc_session_module, "end_managing", lambda: None)
+
+    RpcSession._owns_session = True
+    RpcSession.rpc_session = SimpleNamespace(disconnect=lambda: None)
+    RpcSession._open_db_count = 3
+    RpcSession.pid = 999
+    RpcSession.server_pid = 999
+
+    RpcSession.close()
+
+    assert RpcSession._owns_session is False
+    assert RpcSession._open_db_count == 0
+    assert RpcSession.rpc_session is None
+    assert RpcSession.pid == 0
+    assert RpcSession.server_pid == 0
+
+
+@pytest.mark.skipif(not config["use_grpc"], reason="Applies only for grpc.")
+def test_full_lifecycle_owned_session(monkeypatch):
+    """Start a new session, open two DBs, close them both — session should be terminated."""
+    _reset_rpc_session_state()
+
+    monkeypatch.setattr(rpc_session_module, "is_linux", False)
+    monkeypatch.setattr(rpc_session_module, "env_path", lambda version: r"C:\\fake\\AnsysEM")
+    monkeypatch.setattr(rpc_session_module, "start_managing", lambda *args, **kwargs: None)
+    monkeypatch.setattr(rpc_session_module, "end_managing", lambda: None)
+    monkeypatch.setattr(rpc_session_module, "_SESSION_MOD", SimpleNamespace(current_session=None))
+
+    disconnected = []
+
+    def fake_launch_session(base_path, port_num=None):
+        return SimpleNamespace(
+            local_server_proc=SimpleNamespace(pid=7777),
+            disconnect=lambda: disconnected.append(True),
+        )
+
+    monkeypatch.setattr(rpc_session_module, "launch_session", fake_launch_session)
+
+    RpcSession.start("2026.1", port=55030)
+    RpcSession.acquire()
+    RpcSession.acquire()
+
+    assert RpcSession._open_db_count == 2
+    assert RpcSession.release() is False
+    assert RpcSession._open_db_count == 1
+    assert RpcSession.release() is True
+    assert RpcSession._open_db_count == 0
+    assert len(disconnected) == 1
+
+
+@pytest.mark.skipif(not config["use_grpc"], reason="Applies only for grpc.")
+def test_full_lifecycle_preexisting_session(monkeypatch):
+    """Attach to preexisting session, open a DB, close it — session must NOT be terminated."""
+    _reset_rpc_session_state()
+
+    monkeypatch.setattr(rpc_session_module, "is_linux", False)
+    monkeypatch.setattr(rpc_session_module, "env_path", lambda version: r"C:\\fake\\AnsysEM")
+    monkeypatch.setattr(rpc_session_module, "start_managing", lambda *args, **kwargs: None)
+
+    disconnected = []
+    preexisting = SimpleNamespace(port_num=55040)
+    monkeypatch.setattr(rpc_session_module, "_SESSION_MOD", SimpleNamespace(current_session=preexisting))
+
+    def fake_launch_session(base_path, port_num=None):
+        return SimpleNamespace(
+            local_server_proc=SimpleNamespace(pid=8888),
+            disconnect=lambda: disconnected.append(True),
+        )
+
+    monkeypatch.setattr(rpc_session_module, "launch_session", fake_launch_session)
+
+    RpcSession.start("2026.1", port=55040)
+    RpcSession.acquire()
+
+    assert RpcSession._owns_session is False
+    assert RpcSession.release() is False
+    assert RpcSession.rpc_session is None
+    assert len(disconnected) == 0
+

--- a/tests/unit/test_grpc_in_memory.py
+++ b/tests/unit/test_grpc_in_memory.py
@@ -196,6 +196,7 @@ def test_close_resets_owns_session(monkeypatch):
     _reset_rpc_session_state()
     monkeypatch.setattr(rpc_session_module, "end_managing", lambda: None)
     monkeypatch.setattr(rpc_session_module, "_IS_WINDOWS", False)
+    monkeypatch.setattr(RpcSession, "_wait_for_process_exit", staticmethod(lambda *a, **kw: None))
 
     RpcSession._owns_session = True
     RpcSession.rpc_session = SimpleNamespace(disconnect=lambda: None, local_server_proc=SimpleNamespace(pid=999))
@@ -222,6 +223,7 @@ def test_full_lifecycle_owned_session(monkeypatch):
     monkeypatch.setattr(rpc_session_module, "start_managing", lambda *args, **kwargs: None)
     monkeypatch.setattr(rpc_session_module, "_IS_WINDOWS", False)
     monkeypatch.setattr(rpc_session_module, "end_managing", lambda: None)
+    monkeypatch.setattr(RpcSession, "_wait_for_process_exit", staticmethod(lambda *a, **kw: None))
     monkeypatch.setattr(rpc_session_module, "_SESSION_MOD", SimpleNamespace(current_session=None))
 
     disconnected = []

--- a/tests/unit/test_grpc_in_memory.py
+++ b/tests/unit/test_grpc_in_memory.py
@@ -198,9 +198,7 @@ def test_close_resets_owns_session(monkeypatch):
     monkeypatch.setattr(rpc_session_module, "_IS_WINDOWS", False)
 
     RpcSession._owns_session = True
-    RpcSession.rpc_session = SimpleNamespace(
-        disconnect=lambda: None, local_server_proc=SimpleNamespace(pid=999)
-    )
+    RpcSession.rpc_session = SimpleNamespace(disconnect=lambda: None, local_server_proc=SimpleNamespace(pid=999))
     RpcSession._open_db_count = 3
     RpcSession.pid = 999
     RpcSession.server_pid = 999

--- a/tests/unit/test_grpc_in_memory.py
+++ b/tests/unit/test_grpc_in_memory.py
@@ -361,30 +361,8 @@ def test_edb_close_default_does_not_terminate_when_other_dbs_open(monkeypatch):
 
 
 @pytest.mark.skipif(not config["use_grpc"], reason="Applies only for grpc.")
-def test_edb_close_keep_session_alive(monkeypatch):
-    """edb.close(keep_session_alive=True) should never shut down the server."""
-    _reset_rpc_session_state()
-    close_called = []
-    RpcSession._open_db_count = 1
-    RpcSession.rpc_session = SimpleNamespace(in_memory=False)
-
-    monkeypatch.setattr(RpcSession, "close", staticmethod(lambda: close_called.append(True)))
-
-    edb = EdbInit.__new__(EdbInit)
-    edb.version = "2026.1"
-    edb.logger = settings.logger
-    edb._db = SimpleNamespace(close=lambda: None)
-    edb.grpc = True
-
-    edb.close(keep_session_alive=True)
-
-    assert RpcSession._open_db_count == 0
-    assert len(close_called) == 0  # server kept alive
-
-
-@pytest.mark.skipif(not config["use_grpc"], reason="Applies only for grpc.")
 def test_edb_close_terminate_rpc_session_false_keeps_server(monkeypatch):
-    """Legacy edb.close(terminate_rpc_session=False) should keep server alive."""
+    """edb.close(terminate_rpc_session=False) should keep server alive."""
     _reset_rpc_session_state()
     close_called = []
     RpcSession._open_db_count = 1
@@ -406,7 +384,6 @@ def test_edb_close_terminate_rpc_session_false_keeps_server(monkeypatch):
 
 @pytest.mark.skipif(not config["use_grpc"], reason="Applies only for grpc.")
 def test_edb_close_terminate_rpc_session_true_forces_shutdown(monkeypatch):
-    """Legacy edb.close(terminate_rpc_session=True) should force-kill server."""
     _reset_rpc_session_state()
     close_called = []
     RpcSession._open_db_count = 2

--- a/tests/unit/test_grpc_in_memory.py
+++ b/tests/unit/test_grpc_in_memory.py
@@ -125,32 +125,29 @@ def test_release_does_not_go_below_zero():
 @pytest.mark.skipif(not config["use_grpc"], reason="Applies only for grpc.")
 def test_release_closes_session_when_owned_and_count_reaches_zero(monkeypatch):
     _reset_rpc_session_state()
-    close_called = []
-    monkeypatch.setattr(RpcSession, "close", staticmethod(lambda: close_called.append(True)))
 
     RpcSession._owns_session = True
     RpcSession.rpc_session = SimpleNamespace(in_memory=False)
     RpcSession.acquire()
     result = RpcSession.release()
 
-    assert result is True
-    assert len(close_called) == 1
+    # release() only decrements — it does NOT shut down the server
+    assert result is True  # True means count reached zero
+    assert RpcSession.rpc_session is not None  # server still alive
 
 
 @pytest.mark.skipif(not config["use_grpc"], reason="Applies only for grpc.")
-def test_release_does_not_close_session_when_not_owned(monkeypatch):
+def test_release_returns_false_when_dbs_still_open():
     _reset_rpc_session_state()
-    close_called = []
-    monkeypatch.setattr(RpcSession, "close", staticmethod(lambda: close_called.append(True)))
 
-    RpcSession._owns_session = False
     RpcSession.rpc_session = SimpleNamespace(in_memory=False)
+    RpcSession.acquire()
     RpcSession.acquire()
     result = RpcSession.release()
 
     assert result is False
-    assert len(close_called) == 0
-    assert RpcSession.rpc_session is None
+    assert RpcSession._open_db_count == 1
+    assert RpcSession.rpc_session is not None
 
 
 @pytest.mark.skipif(not config["use_grpc"], reason="Applies only for grpc.")
@@ -216,7 +213,7 @@ def test_close_resets_owns_session(monkeypatch):
 
 @pytest.mark.skipif(not config["use_grpc"], reason="Applies only for grpc.")
 def test_full_lifecycle_owned_session(monkeypatch):
-    """Start a new session, open two DBs, close them both — session should be terminated."""
+    """Start a new session, open two DBs, close them both — server stays alive until explicit close()."""
     _reset_rpc_session_state()
 
     monkeypatch.setattr(rpc_session_module, "is_linux", False)
@@ -242,14 +239,21 @@ def test_full_lifecycle_owned_session(monkeypatch):
     assert RpcSession._open_db_count == 2
     assert RpcSession.release() is False
     assert RpcSession._open_db_count == 1
-    assert RpcSession.release() is True
+    assert RpcSession.release() is True  # count reached zero
     assert RpcSession._open_db_count == 0
+    # Server is NOT disconnected by release — still alive
+    assert len(disconnected) == 0
+    assert RpcSession.rpc_session is not None
+
+    # Explicit close shuts down the server
+    RpcSession.close()
     assert len(disconnected) == 1
+    assert RpcSession.rpc_session is None
 
 
 @pytest.mark.skipif(not config["use_grpc"], reason="Applies only for grpc.")
 def test_full_lifecycle_preexisting_session(monkeypatch):
-    """Attach to preexisting session, open a DB, close it — session must NOT be terminated."""
+    """Attach to preexisting session, open a DB, close it — session stays alive."""
     _reset_rpc_session_state()
 
     monkeypatch.setattr(rpc_session_module, "is_linux", False)
@@ -272,7 +276,154 @@ def test_full_lifecycle_preexisting_session(monkeypatch):
     RpcSession.acquire()
 
     assert RpcSession._owns_session is False
-    assert RpcSession.release() is False
-    assert RpcSession.rpc_session is None
+    assert RpcSession.release() is True  # count reached zero
+    assert RpcSession.rpc_session is not None  # server still alive
     assert len(disconnected) == 0
+
+
+@pytest.mark.skipif(not config["use_grpc"], reason="Applies only for grpc.")
+def test_release_does_not_restart_server_between_tests(monkeypatch):
+    """Simulate two sequential test opens: release should keep server alive so start() reuses it."""
+    _reset_rpc_session_state()
+
+    monkeypatch.setattr(rpc_session_module, "is_linux", False)
+    monkeypatch.setattr(rpc_session_module, "env_path", lambda version: r"C:\\fake\\AnsysEM")
+    monkeypatch.setattr(rpc_session_module, "start_managing", lambda *args, **kwargs: None)
+    monkeypatch.setattr(rpc_session_module, "_SESSION_MOD", SimpleNamespace(current_session=None))
+
+    launch_count = []
+
+    def fake_launch_session(base_path, port_num=None):
+        launch_count.append(1)
+        return SimpleNamespace(
+            local_server_proc=SimpleNamespace(pid=9999),
+            disconnect=lambda: None,
+        )
+
+    monkeypatch.setattr(rpc_session_module, "launch_session", fake_launch_session)
+
+    # First "test": start, open, close DB
+    RpcSession.start("2026.1", port=55050)
+    RpcSession.acquire()
+    RpcSession.release()
+    assert len(launch_count) == 1
+
+    # Second "test": start again — server should already be running
+    RpcSession.start("2026.1", port=55050)
+    RpcSession.acquire()
+    RpcSession.release()
+    # launch_session should NOT have been called again
+    assert len(launch_count) == 1
+
+
+@pytest.mark.skipif(not config["use_grpc"], reason="Applies only for grpc.")
+def test_edb_close_default_terminates_session_when_last_db(monkeypatch):
+    """edb.close() with no args should shut down the server when it's the last DB."""
+    _reset_rpc_session_state()
+    close_called = []
+    RpcSession._open_db_count = 1
+    RpcSession.rpc_session = SimpleNamespace(in_memory=False)
+
+    monkeypatch.setattr(RpcSession, "close", staticmethod(lambda: close_called.append(True)))
+
+    edb = EdbInit.__new__(EdbInit)
+    edb.version = "2026.1"
+    edb.logger = settings.logger
+    edb._db = SimpleNamespace(close=lambda: None)
+    edb.grpc = True
+
+    edb.close()
+
+    assert RpcSession._open_db_count == 0
+    assert len(close_called) == 1  # server was shut down
+
+
+@pytest.mark.skipif(not config["use_grpc"], reason="Applies only for grpc.")
+def test_edb_close_default_does_not_terminate_when_other_dbs_open(monkeypatch):
+    """edb.close() with no args should NOT shut down when other DBs are still open."""
+    _reset_rpc_session_state()
+    close_called = []
+    RpcSession._open_db_count = 2
+    RpcSession.rpc_session = SimpleNamespace(in_memory=False)
+
+    monkeypatch.setattr(RpcSession, "close", staticmethod(lambda: close_called.append(True)))
+
+    edb = EdbInit.__new__(EdbInit)
+    edb.version = "2026.1"
+    edb.logger = settings.logger
+    edb._db = SimpleNamespace(close=lambda: None)
+    edb.grpc = True
+
+    edb.close()
+
+    assert RpcSession._open_db_count == 1
+    assert len(close_called) == 0  # server kept alive
+
+
+@pytest.mark.skipif(not config["use_grpc"], reason="Applies only for grpc.")
+def test_edb_close_keep_session_alive(monkeypatch):
+    """edb.close(keep_session_alive=True) should never shut down the server."""
+    _reset_rpc_session_state()
+    close_called = []
+    RpcSession._open_db_count = 1
+    RpcSession.rpc_session = SimpleNamespace(in_memory=False)
+
+    monkeypatch.setattr(RpcSession, "close", staticmethod(lambda: close_called.append(True)))
+
+    edb = EdbInit.__new__(EdbInit)
+    edb.version = "2026.1"
+    edb.logger = settings.logger
+    edb._db = SimpleNamespace(close=lambda: None)
+    edb.grpc = True
+
+    edb.close(keep_session_alive=True)
+
+    assert RpcSession._open_db_count == 0
+    assert len(close_called) == 0  # server kept alive
+
+
+@pytest.mark.skipif(not config["use_grpc"], reason="Applies only for grpc.")
+def test_edb_close_terminate_rpc_session_false_keeps_server(monkeypatch):
+    """Legacy edb.close(terminate_rpc_session=False) should keep server alive."""
+    _reset_rpc_session_state()
+    close_called = []
+    RpcSession._open_db_count = 1
+    RpcSession.rpc_session = SimpleNamespace(in_memory=False)
+
+    monkeypatch.setattr(RpcSession, "close", staticmethod(lambda: close_called.append(True)))
+
+    edb = EdbInit.__new__(EdbInit)
+    edb.version = "2026.1"
+    edb.logger = settings.logger
+    edb._db = SimpleNamespace(close=lambda: None)
+    edb.grpc = True
+
+    edb.close(terminate_rpc_session=False)
+
+    assert RpcSession._open_db_count == 0
+    assert len(close_called) == 0  # server kept alive
+
+
+@pytest.mark.skipif(not config["use_grpc"], reason="Applies only for grpc.")
+def test_edb_close_terminate_rpc_session_true_forces_shutdown(monkeypatch):
+    """Legacy edb.close(terminate_rpc_session=True) should force-kill server."""
+    _reset_rpc_session_state()
+    close_called = []
+    RpcSession._open_db_count = 2
+    RpcSession.rpc_session = SimpleNamespace(in_memory=False)
+
+    monkeypatch.setattr(RpcSession, "close", staticmethod(lambda: close_called.append(True)))
+
+    edb = EdbInit.__new__(EdbInit)
+    edb.version = "2026.1"
+    edb.logger = settings.logger
+    edb._db = SimpleNamespace(close=lambda: None)
+    edb.grpc = True
+
+    edb.close(terminate_rpc_session=True)
+
+    # Force-kill doesn't call release, so count is unchanged
+    assert RpcSession._open_db_count == 2
+    assert len(close_called) == 1
+
 

--- a/tests/unit/test_grpc_in_memory.py
+++ b/tests/unit/test_grpc_in_memory.py
@@ -195,9 +195,12 @@ def test_start_sets_owns_session_false_when_preexisting_session(monkeypatch):
 def test_close_resets_owns_session(monkeypatch):
     _reset_rpc_session_state()
     monkeypatch.setattr(rpc_session_module, "end_managing", lambda: None)
+    monkeypatch.setattr(rpc_session_module, "_IS_WINDOWS", False)
 
     RpcSession._owns_session = True
-    RpcSession.rpc_session = SimpleNamespace(disconnect=lambda: None)
+    RpcSession.rpc_session = SimpleNamespace(
+        disconnect=lambda: None, local_server_proc=SimpleNamespace(pid=999)
+    )
     RpcSession._open_db_count = 3
     RpcSession.pid = 999
     RpcSession.server_pid = 999
@@ -219,6 +222,7 @@ def test_full_lifecycle_owned_session(monkeypatch):
     monkeypatch.setattr(rpc_session_module, "is_linux", False)
     monkeypatch.setattr(rpc_session_module, "env_path", lambda version: r"C:\\fake\\AnsysEM")
     monkeypatch.setattr(rpc_session_module, "start_managing", lambda *args, **kwargs: None)
+    monkeypatch.setattr(rpc_session_module, "_IS_WINDOWS", False)
     monkeypatch.setattr(rpc_session_module, "end_managing", lambda: None)
     monkeypatch.setattr(rpc_session_module, "_SESSION_MOD", SimpleNamespace(current_session=None))
 

--- a/tests/unit/test_grpc_in_memory.py
+++ b/tests/unit/test_grpc_in_memory.py
@@ -275,4 +275,3 @@ def test_full_lifecycle_preexisting_session(monkeypatch):
     assert RpcSession.release() is False
     assert RpcSession.rpc_session is None
     assert len(disconnected) == 0
-

--- a/tests/unit/test_grpc_in_memory.py
+++ b/tests/unit/test_grpc_in_memory.py
@@ -290,13 +290,14 @@ def test_release_does_not_restart_server_between_tests(monkeypatch):
     monkeypatch.setattr(rpc_session_module, "env_path", lambda version: r"C:\\fake\\AnsysEM")
     monkeypatch.setattr(rpc_session_module, "start_managing", lambda *args, **kwargs: None)
     monkeypatch.setattr(rpc_session_module, "_SESSION_MOD", SimpleNamespace(current_session=None))
+    monkeypatch.setattr(rpc_session_module.psutil, "pid_exists", lambda pid: True)
 
     launch_count = []
 
     def fake_launch_session(base_path, port_num=None):
         launch_count.append(1)
         return SimpleNamespace(
-            local_server_proc=SimpleNamespace(pid=9999),
+            local_server_proc=SimpleNamespace(pid=9999, poll=lambda: None),
             disconnect=lambda: None,
         )
 

--- a/tests/unit/test_grpc_in_memory.py
+++ b/tests/unit/test_grpc_in_memory.py
@@ -425,5 +425,3 @@ def test_edb_close_terminate_rpc_session_true_forces_shutdown(monkeypatch):
     # Force-kill doesn't call release, so count is unchanged
     assert RpcSession._open_db_count == 2
     assert len(close_called) == 1
-
-


### PR DESCRIPTION
This PR is adressing issue #2105.

Fixing issue #2108 
Addressing random failure on Windows CI:
On Windows CI, the gRPC server process cleanup is slower due to socket TIME_WAIT states and process teardown delays. When close_rpc_session (class-scoped fixture) kills the server between test classes, the next class's RpcSession.start() could:
Reuse a stale rpc_session reference pointing at a dead server process
Have _SESSION_MOD.current_session still referencing the old dead session, causing __start_rpc_server to attach to it instead of starting fresh
Fail to bind the new server's port because the old socket hasn't been released yet
Fixes applied:
rpc_session.py - Health check in start(): Before reusing an existing session, validate the server process is actually alive via _is_server_alive(). If the process is dead, clean up and start fresh.
rpc_session.py - _reset_session_state(): New helper that clears all session state AND sets _SESSION_MOD.current_session = None. This prevents __start_rpc_server from falsely detecting a "preexisting" session that's actually dead.
rpc_session.py - close() hardened:
Wrapped end_managing() and disconnect() in try/except to prevent cascading failures
Added Windows-specific 1.0s delay (vs 0.1s on Linux) after disconnect to allow socket cleanup
Uses _reset_session_state() to clear all state including _SESSION_MOD.current_session
edb_init.py - Null guard in close(): Added if self._db is not None check with try/except around self._db.close() to prevent "Illegal operation on a null object" when close is called on an already-closed or failed EDB.

closes #2105 
closes #2108 