### PR TITLE
CHORE: Bump dev version and cleanup

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -77,7 +77,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - name: Build wheelhouse and perform smoke test
         id: build-wheelhouse

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -81,7 +81,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - name: Build wheelhouse and perform smoke test
         id: build-wheelhouse

--- a/doc/changelog.d/2117.maintenance.md
+++ b/doc/changelog.d/2117.maintenance.md
@@ -1,0 +1,1 @@
+Bump dev version and cleanup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=3.2,<3.13"] # THIS SHOULD BE REVERTED TO '["flit_core >=3.2,<4"]'
+requires = ["flit_core >=3.2,<4"]
 build-backend = "flit_core.buildapi"
 
 
@@ -21,7 +21,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13"
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14"
 ]
 
 dependencies = [

--- a/src/pyedb/__init__.py
+++ b/src/pyedb/__init__.py
@@ -59,7 +59,7 @@ deprecation_warning()
 #
 
 pyedb_path = os.path.dirname(__file__)
-__version__ = "0.75.dev0"
+__version__ = "0.76.dev0"
 version = __version__
 
 #


### PR DESCRIPTION
This PR updates the project to add support for Python 3.14, updates metadata and workflow configurations accordingly, and bumps the project version to 0.76.dev0.