### PR TITLE
FIX: Unpin dependencies

### DIFF
--- a/doc/changelog.d/2180.fixed.md
+++ b/doc/changelog.d/2180.fixed.md
@@ -1,0 +1,1 @@
+Unpin dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ classifiers = [
 dependencies = [
     "numpy>=1.20.0,<3",
     "pydantic>=2.6.4,<2.14",
-    "toml==0.10.2",
-    "ansys-edb-core==0.3.1",
+    "toml>=0.10.2",
+    "ansys-edb-core>=0.3.1",
     "psutil",
     "defusedxml>=0.7,<8.0",
     "xmltodict"
@@ -79,7 +79,7 @@ doc = [
     "matplotlib>=3.5.0,<3.11",
     "nbsphinx>=0.9.0,<0.10",
     "nbconvert<7.18",
-    "numpydoc==1.10.0",
+    "numpydoc>=1.10.0",
     "pandas>=1.1.0,<2.4",
     "pypandoc>=1.10.0,<1.18",
     # NOTE: Remove recommonmark once examples are reworked.
@@ -87,7 +87,7 @@ doc = [
     "Rtree>=1.2.0",
     "shapely",
     "Sphinx>=7.1.0,<9.1",
-    "sphinx-autobuild==2024.10.3",
+    "sphinx-autobuild>=2024.10.3",
     "sphinx-copybutton>=0.5.0,<0.6",
     "sphinx-gallery>=0.14.0,<0.22",
     "sphinx_design>=0.4.0,<0.7"


### PR DESCRIPTION
Unpin dependencies to provide only minimum versions.  I have seen some discussion that this should only be applied to runtime dependencies and test/CI/CD-type dependencies should actually be pinned, but this was not the case here already so I left them as is except for unpinning any that were currently pinned.

Closes #2179 