### PR TITLE
FIX: HFSS-PI simulation setup cast failing

### DIFF
--- a/doc/changelog.d/2199.fixed.md
+++ b/doc/changelog.d/2199.fixed.md
@@ -1,0 +1,1 @@
+HFSS-PI simulation setup cast failing

--- a/src/pyedb/grpc/database/simulation_setup/hfss_pi_simulation_setup.py
+++ b/src/pyedb/grpc/database/simulation_setup/hfss_pi_simulation_setup.py
@@ -36,6 +36,8 @@ class HFSSPISimulationSetup(SimulationSetup):
 
     def __init__(self, pedb, core: "CoreHFSSPISimulationSetup"):
         super().__init__(pedb, core)
+        if not isinstance(core, CoreHFSSPISimulationSetup):
+            core = CoreHFSSPISimulationSetup(core.msg)
         self.core = core
         self._pedb = pedb
 

--- a/src/pyedb/grpc/database/simulation_setup/hfss_simulation_setup.py
+++ b/src/pyedb/grpc/database/simulation_setup/hfss_simulation_setup.py
@@ -49,6 +49,8 @@ class HfssSimulationSetup(SimulationSetup):
 
     def __init__(self, pedb, core: "CoreHfssSimulationSetup", name: str = None):
         super().__init__(pedb, core)
+        if not isinstance(core, CoreHfssSimulationSetup):
+            core = CoreHfssSimulationSetup(core.msg)
         self.core = core
         self._pedb = pedb
         self._name = name

--- a/src/pyedb/grpc/database/simulation_setup/q3d_simulation_setup.py
+++ b/src/pyedb/grpc/database/simulation_setup/q3d_simulation_setup.py
@@ -43,6 +43,8 @@ class Q3DSimulationSetup(SimulationSetup):
 
     def __init__(self, pedb, core: "GrpcQ3DSimulationSetup"):
         super().__init__(pedb, core)
+        if not isinstance(core, CoreQ3DSimulationSetup):
+            core = CoreQ3DSimulationSetup(core.msg)
         self.core: CoreQ3DSimulationSetup = core
         self._pedb = pedb
 

--- a/src/pyedb/grpc/database/simulation_setup/raptor_x_simulation_setup.py
+++ b/src/pyedb/grpc/database/simulation_setup/raptor_x_simulation_setup.py
@@ -41,6 +41,8 @@ class RaptorXSimulationSetup(SimulationSetup):
 
     def __init__(self, pedb, core: "CoreRaptorXSimulationSetup"):
         super().__init__(pedb, core)
+        if not isinstance(core, CoreRaptorXSimulationSetup):
+            core = CoreRaptorXSimulationSetup(core.msg)
         self.core = core
         self._pedb = pedb
 

--- a/src/pyedb/grpc/database/simulation_setup/siwave_dcir_simulation_setup.py
+++ b/src/pyedb/grpc/database/simulation_setup/siwave_dcir_simulation_setup.py
@@ -36,6 +36,8 @@ class SIWaveDCIRSimulationSetup(SimulationSetup):
 
     def __init__(self, pedb, core: "CoreSIWaveDCIRSimulationSetup"):
         super().__init__(pedb, core)
+        if not isinstance(core, CoreSIWaveDCIRSimulationSetup):
+            core = CoreSIWaveDCIRSimulationSetup(core.msg)
         self.core = core
         self._pedb = pedb
 

--- a/src/pyedb/grpc/database/simulation_setup/siwave_simulation_setup.py
+++ b/src/pyedb/grpc/database/simulation_setup/siwave_simulation_setup.py
@@ -40,6 +40,8 @@ class SiwaveSimulationSetup(SimulationSetup):
 
     def __init__(self, pedb, core: "CoreSIWaveSimulationSetup"):
         super().__init__(pedb, core)
+        if not isinstance(core, CoreSIWaveSimulationSetup):
+            core = CoreSIWaveSimulationSetup(core.msg)
         self.core: CoreSIWaveSimulationSetup = core
         self._pedb = pedb
 

--- a/src/pyedb/grpc/database/simulation_setups.py
+++ b/src/pyedb/grpc/database/simulation_setups.py
@@ -24,6 +24,7 @@
 from typing import cast
 
 from ansys.edb.core.database import ProductIdType as CoreProductIdType
+from ansys.edb.core.simulation_setup.simulation_setup import SimulationSetup as CoreSimulationSetup
 
 from pyedb.generic.general_methods import generate_unique_name
 from pyedb.grpc.database.simulation_setup.hfss_pi_simulation_setup import HFSSPISimulationSetup
@@ -51,6 +52,52 @@ class SimulationSetups:
         self._siwave_cpa_setup: dict[str, SIWaveCPASimulationSetup] = {}
         self._hfss_pi_setups: dict[str, HFSSPISimulationSetup] = {}
 
+    def _raw_simulation_setups(self) -> list:
+        """Return raw (uncast) core SimulationSetup objects from the active cell.
+
+        This helper exists to work around a limitation in the public
+        ``ansys-edb-core`` API.  ``Cell.simulation_setups`` internally calls
+        ``.cast()`` on every object it returns.  The ``cast()`` implementation
+        in the core library only handles a subset of solver types (HFSS,
+        SI_WAVE, SI_WAVE_DCIR, RAPTOR_X) and returns ``None`` for any type it
+        does not recognise — most notably ``HFSS_PI``.  Those ``None`` values
+        are then silently discarded during the usual None-filtering step,
+        making the ``hfss_pi`` property (and the ``setups`` aggregator) always
+        return an empty dict even after a valid HFSS PI setup has been created.
+
+        To avoid this, this method bypasses ``.cast()`` entirely: it calls the
+        underlying gRPC stub (``_Cell__stub.GetSimulationSetups``) directly and
+        wraps the raw protobuf messages in plain ``CoreSimulationSetup``
+        objects.  The type is then read via ``setup.type.name`` inside each
+        property and the correct PyEDB wrapper class is instantiated there.
+
+        If the private stub attribute is not accessible for any reason (e.g. a
+        future API refactor), the method falls back to the public
+        ``active_cell.simulation_setups`` call so that HFSS, SI_WAVE and other
+        already-handled types remain functional.
+
+        Returns
+        -------
+        list[CoreSimulationSetup]
+            All simulation setups present in the active cell, including
+            ``HFSS_PI`` and any other types not covered by ``.cast()``.
+        """
+        try:
+            # Access the private name-mangled gRPC stub on Cell directly so we
+            # can call GetSimulationSetups without going through .cast(), which
+            # would drop HFSS_PI setups (see docstring above).
+            stub = self._pedb.active_cell._Cell__stub
+            msgs = stub.GetSimulationSetups(self._pedb.active_cell.msg).items
+            return [CoreSimulationSetup(msg) for msg in msgs]
+        except Exception:
+            # Fall back to the public API if the private stub is not accessible.
+            # Note: HFSS_PI setups will be missing in this path due to the
+            # .cast() issue described above, but all other solver types work.
+            setups = self._pedb.active_cell.simulation_setups
+            if isinstance(setups, list):
+                return [s for s in setups if s is not None]
+            return []
+
     @property
     def hfss(self) -> dict[str, HfssSimulationSetup]:
         """HFSS simulation setups.
@@ -61,10 +108,7 @@ class SimulationSetups:
         hfss_simulation_setup.HFSSSimulationSetup>`]
         """
         self._hfss_setups = {}
-        setups = self._pedb.active_cell.simulation_setups
-        # grpc returns list of None
-        if isinstance(setups, list):
-            setups = [s for s in setups if s is not None]
+        setups = self._raw_simulation_setups()
         if not setups:
             return self._hfss_setups
         self._hfss_setups = {
@@ -84,10 +128,7 @@ class SimulationSetups:
         siwave_simulation_setup.SIWaveSimulationSetup>`]
         """
         self._siwave_setups = {}
-        setups = self._pedb.active_cell.simulation_setups
-        # grpc returns list of None
-        if isinstance(setups, list):
-            setups = [s for s in setups if s is not None]
+        setups = self._raw_simulation_setups()
         if not setups:
             return self._siwave_setups
         self._siwave_setups = {
@@ -107,10 +148,7 @@ class SimulationSetups:
         siwave_dcir_simulation_setup.SIWaveDCIRSimulationSetup>`]
         """
         self._siwave_dcir_setups = {}
-        setups = self._pedb.active_cell.simulation_setups
-        # grpc returns list of None
-        if isinstance(setups, list):
-            setups = [s for s in setups if s is not None]
+        setups = self._raw_simulation_setups()
         if not setups:
             return self._siwave_dcir_setups
         self._siwave_dcir_setups = {
@@ -154,10 +192,7 @@ class SimulationSetups:
         raptor_x_simulation_setup.RaptorXSimulationSetup>`]
         """
         self._raptorx_setups = {}
-        setups = self._pedb.active_cell.simulation_setups
-        # grpc returns list of None
-        if isinstance(setups, list):
-            setups = [s for s in setups if s is not None]
+        setups = self._raw_simulation_setups()
         if not setups:
             return self._raptorx_setups
         self._raptorx_setups = {
@@ -177,10 +212,7 @@ class SimulationSetups:
         q3d_simulation_setup.Q3DSimulationSetup>`]
         """
         self._q3d_setups = {}
-        setups = self._pedb.active_cell.simulation_setups
-        # grpc returns list of None
-        if isinstance(setups, list):
-            setups = [s for s in setups if s is not None]
+        setups = self._raw_simulation_setups()
         if not setups:
             return self._q3d_setups
         self._q3d_setups = {
@@ -200,10 +232,7 @@ class SimulationSetups:
         hfss_pi_simulation_setup.HFSSPISimulationSetup>`]
         """
         self._hfss_pi_setups = {}
-        setups = self._pedb.active_cell.simulation_setups
-        # grpc returns list of None
-        if isinstance(setups, list):
-            setups = [s for s in setups if s is not None]
+        setups = self._raw_simulation_setups()
         if not setups:
             return self._hfss_pi_setups
         self._hfss_pi_setups = {

--- a/src/pyedb/grpc/edb.py
+++ b/src/pyedb/grpc/edb.py
@@ -266,6 +266,7 @@ class Edb(EdbInit):
         self.isaedtowned = isaedtowned
         self.isreadonly = isreadonly
         self._setups = {}
+        self._simulation_setups = None
         if cellname:
             self.cellname = cellname
         else:
@@ -2367,7 +2368,9 @@ class Edb(EdbInit):
     @property
     def simulation_setups(self) -> SimulationSetups:
         """Get all simulation setups object."""
-        return SimulationSetups(self)
+        if not hasattr(self, "_simulation_setups") or self._simulation_setups is None:
+            self._simulation_setups = SimulationSetups(self)
+        return self._simulation_setups
 
     @property
     @deprecated("Use simulation_setups.hfss property instead.", category=None)
@@ -3439,3 +3442,5 @@ class Edb(EdbInit):
         # Materials and source excitation
         self._materials = Materials(self)
         self._source_excitation = SourceExcitation(self)
+        # Reset simulation setups cache so it is re-created for the new active cell
+        self._simulation_setups = None

--- a/tests/system/test_edb_simulation_setups.py
+++ b/tests/system/test_edb_simulation_setups.py
@@ -803,3 +803,148 @@ class TestClass(BaseTestClass):
         setup = edbapp.setups["setup_1"]
         assert not setup.settings.use_loop_res_for_per_pin
         edbapp.close(terminate_rpc_session=False)
+
+    @pytest.mark.skipif(not config["use_grpc"], reason="DotNet skipping")
+    def test_hfss_pi_setup_create_and_properties(self):
+        """Create an HFSS PI setup and verify basic properties."""
+        edbapp = self.edb_examples.create_empty_edb()
+        setup = edbapp.simulation_setups.create_hfss_pi_setup(name="hfss_pi_1")
+        assert setup is not None
+        assert not setup.is_null
+        assert "hfss_pi_1" in edbapp.simulation_setups.hfss_pi
+        edbapp.close(terminate_rpc_session=False)
+
+    @pytest.mark.skipif(not config["use_grpc"], reason="DotNet skipping")
+    def test_hfss_pi_setup_create_with_sweep(self):
+        """Create an HFSS PI setup with a frequency sweep."""
+        edbapp = self.edb_examples.create_empty_edb()
+        setup = edbapp.simulation_setups.create_hfss_pi_setup(
+            name="hfss_pi_sweep",
+            start_freq=1e9,
+            stop_freq=10e9,
+            step_freq=1e8,
+        )
+        assert setup is not None
+        assert len(setup.sweep_data) > 0
+        edbapp.close(terminate_rpc_session=False)
+
+    @pytest.mark.skipif(not config["use_grpc"], reason="DotNet skipping")
+    def test_create_setup_with_unknown_solver_falls_back_to_hfss(self):
+        """Passing an unknown solver name to create() should fall back to HFSS."""
+        edbapp = self.edb_examples.create_empty_edb()
+        setup = edbapp.simulation_setups.create(name="fallback_setup", solver="unknown_solver")
+        assert setup is not None
+        assert "fallback_setup" in edbapp.simulation_setups.hfss
+        edbapp.close(terminate_rpc_session=False)
+
+    @pytest.mark.skipif(not config["use_grpc"], reason="DotNet skipping")
+    def test_create_setup_returns_none_for_duplicate_name(self):
+        """create() must return None and log an error if setup already exists."""
+        edbapp = self.edb_examples.create_empty_edb()
+        edbapp.simulation_setups.create(name="dup_setup", solver="hfss")
+        result = edbapp.simulation_setups.create(name="dup_setup", solver="hfss")
+        assert result is None
+        edbapp.close(terminate_rpc_session=False)
+
+    @pytest.mark.skipif(not config["use_grpc"], reason="DotNet skipping")
+    def test_hfss_pi_property_empty_when_no_setups(self):
+        """hfss_pi property returns empty dict when no HFSS PI setups exist."""
+        edbapp = self.edb_examples.create_empty_edb()
+        assert edbapp.simulation_setups.hfss_pi == {}
+        edbapp.close(terminate_rpc_session=False)
+
+    @pytest.mark.skipif(not config["use_grpc"], reason="DotNet skipping")
+    def test_q3d_property_empty_when_no_q3d_setups(self):
+        """q3d property returns empty dict when no Q3D setups exist."""
+        edbapp = self.edb_examples.create_empty_edb()
+        assert edbapp.simulation_setups.q3d == {}
+        edbapp.close(terminate_rpc_session=False)
+
+    @pytest.mark.skipif(not config["use_grpc"], reason="DotNet skipping")
+    def test_raptor_x_property_empty_when_no_raptor_x_setups(self):
+        """raptor_x property returns empty dict when no RaptorX setups exist."""
+        edbapp = self.edb_examples.create_empty_edb()
+        assert edbapp.simulation_setups.raptor_x == {}
+        edbapp.close(terminate_rpc_session=False)
+
+    @pytest.mark.skipif(not config["use_grpc"], reason="DotNet skipping")
+    def test_siwave_dcir_property_empty_when_no_setups(self):
+        """siwave_dcir property returns empty dict when no DCIR setups exist."""
+        edbapp = self.edb_examples.create_empty_edb()
+        assert edbapp.simulation_setups.siwave_dcir == {}
+        edbapp.close(terminate_rpc_session=False)
+
+    @pytest.mark.skipif(not config["use_grpc"], reason="DotNet skipping")
+    def test_siwave_property_empty_when_no_setups(self):
+        """siwave property returns empty dict when no SIWave setups exist."""
+        edbapp = self.edb_examples.create_empty_edb()
+        assert edbapp.simulation_setups.siwave == {}
+        edbapp.close(terminate_rpc_session=False)
+
+    @pytest.mark.skipif(not config["use_grpc"], reason="DotNet skipping")
+    def test_create_siwave_cpa_setup_creates_and_stores(self):
+        """create_siwave_cpa_setup creates a CPA setup and stores it internally."""
+        edbapp = self.edb_examples.create_empty_edb()
+        setup = edbapp.simulation_setups.create_siwave_cpa_setup(name="my_cpa_setup")
+        assert setup is not None
+        assert "my_cpa_setup" in edbapp.simulation_setups._siwave_cpa_setup
+        edbapp.close(terminate_rpc_session=False)
+
+    @pytest.mark.skipif(not config["use_grpc"], reason="DotNet skipping")
+    def test_create_siwave_cpa_setup_duplicate_returns_existing(self):
+        """create_siwave_cpa_setup returns the existing setup if called with the same name."""
+        edbapp = self.edb_examples.create_empty_edb()
+        setup1 = edbapp.simulation_setups.create_siwave_cpa_setup(name="cpa_dup")
+        setup2 = edbapp.simulation_setups.create_siwave_cpa_setup(name="cpa_dup")
+        assert setup2 is setup1
+        edbapp.close(terminate_rpc_session=False)
+
+    @pytest.mark.skipif(not config["use_grpc"], reason="DotNet skipping")
+    def test_create_hfss_setup_without_sweep(self):
+        """create_hfss_setup with no frequency params should not add a sweep."""
+        edbapp = self.edb_examples.create_empty_edb()
+        setup = edbapp.simulation_setups.create_hfss_setup(name="hfss_no_sweep")
+        assert setup is not None
+        assert len(setup.sweep_data) == 0
+        edbapp.close(terminate_rpc_session=False)
+
+    @pytest.mark.skipif(not config["use_grpc"], reason="DotNet skipping")
+    def test_create_siwave_setup_without_sweep(self):
+        """create_siwave_setup with no frequency params should not add a sweep."""
+        edbapp = self.edb_examples.create_empty_edb()
+        setup = edbapp.simulation_setups.create_siwave_setup(name="si_no_sweep")
+        assert setup is not None
+        edbapp.close(terminate_rpc_session=False)
+
+    @pytest.mark.skipif(not config["use_grpc"], reason="DotNet skipping")
+    def test_setups_property_merges_all_solver_types(self):
+        """setups property should aggregate all solver setup dicts."""
+        edbapp = self.edb_examples.create_empty_edb()
+        edbapp.simulation_setups.create_hfss_setup(name="hfss_merged")
+        edbapp.simulation_setups.create_siwave_setup(name="si_merged")
+        all_setups = edbapp.simulation_setups.setups
+        assert "hfss_merged" in all_setups
+        assert "si_merged" in all_setups
+        edbapp.close(terminate_rpc_session=False)
+
+    @pytest.mark.skipif(not config["use_grpc"], reason="DotNet skipping")
+    def test_create_raptor_x_setup_with_zero_start_freq(self):
+        """create_raptor_x_setup with start_freq=0 should still add a sweep (not None)."""
+        edbapp = self.edb_examples.create_empty_edb()
+        setup = edbapp.simulation_setups.create_raptor_x_setup(
+            name="rx_zero_start",
+            start_freq=0,
+            stop_freq=10e9,
+            step_freq=1e8,
+        )
+        assert setup is not None
+        assert len(setup.sweep_data) > 0
+        edbapp.close(terminate_rpc_session=False)
+
+    @pytest.mark.skipif(not config["use_grpc"], reason="DotNet skipping")
+    def test_create_q3d_setup_without_sweep(self):
+        """create_q3d_setup with no frequency params should not add a sweep."""
+        edbapp = self.edb_examples.create_empty_edb()
+        setup = edbapp.simulation_setups.create_q3d_setup(name="q3d_no_sweep")
+        assert setup is not None
+        edbapp.close(terminate_rpc_session=False)

--- a/tests/unit/test_simulation_setups.py
+++ b/tests/unit/test_simulation_setups.py
@@ -32,11 +32,6 @@ from pyedb.grpc.database.simulation_setups import SimulationSetups
 pytestmark = [pytest.mark.unit, pytest.mark.grpc]
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
 def _make_setup_stub(name: str, type_name: str):
     """Return a minimal stub that mimics a gRPC SimulationSetup object."""
     stub = SimpleNamespace()
@@ -60,11 +55,6 @@ def _make_pedb(setups_list=None, existing_setups_names=None):
 def _patch_raw(ss, setups_list):
     """Patch _raw_simulation_setups on a SimulationSetups instance."""
     return patch.object(ss, "_raw_simulation_setups", return_value=setups_list if setups_list is not None else [])
-
-
-# ---------------------------------------------------------------------------
-# Property: hfss
-# ---------------------------------------------------------------------------
 
 
 class TestHfssProperty:
@@ -111,11 +101,6 @@ class TestHfssProperty:
             assert ss.hfss == {}
 
 
-# ---------------------------------------------------------------------------
-# Property: siwave
-# ---------------------------------------------------------------------------
-
-
 class TestSiwaveProperty:
     def test_returns_empty_dict_when_no_setups(self):
         pedb = _make_pedb()
@@ -138,11 +123,6 @@ class TestSiwaveProperty:
 
         assert "setup_si" in result
         assert "setup_hfss" not in result
-
-
-# ---------------------------------------------------------------------------
-# Property: siwave_dcir
-# ---------------------------------------------------------------------------
 
 
 class TestSiwaveDcirProperty:
@@ -169,11 +149,6 @@ class TestSiwaveDcirProperty:
         assert "setup_other" not in result
 
 
-# ---------------------------------------------------------------------------
-# Property: raptor_x
-# ---------------------------------------------------------------------------
-
-
 class TestRaptorXProperty:
     def test_returns_empty_dict_when_no_setups(self):
         pedb = _make_pedb()
@@ -196,11 +171,6 @@ class TestRaptorXProperty:
         assert "setup_rx" in result
 
 
-# ---------------------------------------------------------------------------
-# Property: q3d
-# ---------------------------------------------------------------------------
-
-
 class TestQ3dProperty:
     def test_returns_empty_dict_when_no_setups(self):
         pedb = _make_pedb()
@@ -221,11 +191,6 @@ class TestQ3dProperty:
                 result = ss.q3d
 
         assert "setup_q3d" in result
-
-
-# ---------------------------------------------------------------------------
-# Property: hfss_pi
-# ---------------------------------------------------------------------------
 
 
 class TestHfsspiProperty:
@@ -257,11 +222,6 @@ class TestHfsspiProperty:
         ss = SimulationSetups(pedb)
         with _patch_raw(ss, [stub]):
             assert ss.hfss_pi == {}
-
-
-# ---------------------------------------------------------------------------
-# Property: siwave_cpa
-# ---------------------------------------------------------------------------
 
 
 class TestSiwaveCpaProperty:
@@ -302,11 +262,6 @@ class TestSiwaveCpaProperty:
         assert "my_cpa" in result
 
 
-# ---------------------------------------------------------------------------
-# Property: setups (aggregator)
-# ---------------------------------------------------------------------------
-
-
 class TestSetupsProperty:
     def test_merges_all_solver_dicts(self):
         pedb = _make_pedb()
@@ -341,11 +296,6 @@ class TestSetupsProperty:
 
         assert "my_hfss" in result
         assert "my_si" in result
-
-
-# ---------------------------------------------------------------------------
-# Method: create
-# ---------------------------------------------------------------------------
 
 
 class TestCreate:
@@ -450,11 +400,6 @@ class TestCreate:
         assert result is fake_setup
 
 
-# ---------------------------------------------------------------------------
-# Method: _raw_simulation_setups
-# ---------------------------------------------------------------------------
-
-
 class TestRawSimulationSetups:
     def test_falls_back_to_public_api_when_stub_not_accessible(self):
         """If the private Cell stub is not accessible, fall back to active_cell.simulation_setups."""
@@ -482,11 +427,6 @@ class TestRawSimulationSetups:
         ss = SimulationSetups(pedb)
         result = ss._raw_simulation_setups()
         assert len(result) == 1
-
-
-# ---------------------------------------------------------------------------
-# Method: create_hfss_setup
-# ---------------------------------------------------------------------------
 
 
 class TestCreateHfssSetup:
@@ -522,11 +462,6 @@ class TestCreateHfssSetup:
         assert fake_setup.my_custom_attr == 42
 
 
-# ---------------------------------------------------------------------------
-# Method: create_hfss_pi_setup
-# ---------------------------------------------------------------------------
-
-
 class TestCreateHfsspiSetup:
     def test_creates_without_sweep(self):
         pedb = _make_pedb()
@@ -560,11 +495,6 @@ class TestCreateHfsspiSetup:
         assert fake_setup.extra_param == "hello"
 
 
-# ---------------------------------------------------------------------------
-# Method: create_siwave_setup
-# ---------------------------------------------------------------------------
-
-
 class TestCreateSiwaveSetup:
     def test_creates_without_sweep(self):
         pedb = _make_pedb()
@@ -590,11 +520,6 @@ class TestCreateSiwaveSetup:
         fake_setup.add_sweep.assert_called_once()
 
 
-# ---------------------------------------------------------------------------
-# Method: create_siwave_dcir_setup
-# ---------------------------------------------------------------------------
-
-
 class TestCreateSiwaveDcirSetup:
     def test_creates_dcir_setup(self):
         pedb = _make_pedb()
@@ -611,11 +536,6 @@ class TestCreateSiwaveDcirSetup:
         with patch.object(ss, "create", return_value=fake_setup):
             ss.create_siwave_dcir_setup(name="my_dcir", foo="bar")
         assert fake_setup.foo == "bar"
-
-
-# ---------------------------------------------------------------------------
-# Method: create_siwave_cpa_setup
-# ---------------------------------------------------------------------------
 
 
 class TestCreateSiwaveCpaSetup:
@@ -678,11 +598,6 @@ class TestCreateSiwaveCpaSetup:
         assert fake_cpa.my_kwarg == "value"
 
 
-# ---------------------------------------------------------------------------
-# Method: create_raptor_x_setup
-# ---------------------------------------------------------------------------
-
-
 class TestCreateRaptorXSetup:
     def test_creates_without_sweep(self):
         pedb = _make_pedb()
@@ -715,11 +630,6 @@ class TestCreateRaptorXSetup:
         with patch.object(ss, "create", return_value=fake_setup):
             ss.create_raptor_x_setup(name="my_rx", start_freq=1e9)
         fake_setup.add_sweep.assert_not_called()
-
-
-# ---------------------------------------------------------------------------
-# Method: create_q3d_setup
-# ---------------------------------------------------------------------------
 
 
 class TestCreateQ3dSetup:

--- a/tests/unit/test_simulation_setups.py
+++ b/tests/unit/test_simulation_setups.py
@@ -1,0 +1,755 @@
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Unit tests for SimulationSetups container class (no EDB license required)."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pyedb.grpc.database.simulation_setups import SimulationSetups
+
+pytestmark = [pytest.mark.unit, pytest.mark.grpc]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_setup_stub(name: str, type_name: str):
+    """Return a minimal stub that mimics a gRPC SimulationSetup object."""
+    stub = SimpleNamespace()
+    stub.name = name
+    stub.type = SimpleNamespace(name=type_name)
+    return stub
+
+
+def _make_pedb(setups_list=None, existing_setups_names=None):
+    """Build a minimal mock pedb object."""
+    pedb = MagicMock()
+    # active_cell.simulation_setups is no longer used by SimulationSetups properties;
+    # _raw_simulation_setups() is called instead. We leave it accessible for fallback.
+    pedb.active_cell.simulation_setups = setups_list if setups_list is not None else []
+    # setups property used by create() duplicate check
+    pedb.setups = {name: MagicMock() for name in (existing_setups_names or [])}
+    pedb.active_cell.get_product_property.return_value = SimpleNamespace(value="")
+    return pedb
+
+
+def _patch_raw(ss, setups_list):
+    """Patch _raw_simulation_setups on a SimulationSetups instance."""
+    return patch.object(ss, "_raw_simulation_setups", return_value=setups_list if setups_list is not None else [])
+
+
+# ---------------------------------------------------------------------------
+# Property: hfss
+# ---------------------------------------------------------------------------
+
+
+class TestHfssProperty:
+    def test_returns_empty_dict_when_no_setups(self):
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        with _patch_raw(ss, []):
+            assert ss.hfss == {}
+
+    def test_returns_empty_dict_when_setups_is_none(self):
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        with _patch_raw(ss, []):
+            assert ss.hfss == {}
+
+    def test_filters_none_entries_from_grpc_list(self):
+        # _raw_simulation_setups already filters Nones; empty list maps to empty dict
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        with _patch_raw(ss, []):
+            assert ss.hfss == {}
+
+    def test_returns_only_hfss_setups(self):
+        stub_hfss = _make_setup_stub("setup_hfss", "hfss")
+        stub_si = _make_setup_stub("setup_si", "si_wave")
+        pedb = _make_pedb()
+
+        with patch(
+            "pyedb.grpc.database.simulation_setups.HfssSimulationSetup",
+            side_effect=lambda pedb, s: SimpleNamespace(name=s.name),
+        ):
+            ss = SimulationSetups(pedb)
+            with _patch_raw(ss, [stub_hfss, stub_si]):
+                result = ss.hfss
+
+        assert "setup_hfss" in result
+        assert "setup_si" not in result
+
+    def test_ignores_setup_with_none_type(self):
+        stub = SimpleNamespace(name="bad", type=None)
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        with _patch_raw(ss, [stub]):
+            assert ss.hfss == {}
+
+
+# ---------------------------------------------------------------------------
+# Property: siwave
+# ---------------------------------------------------------------------------
+
+
+class TestSiwaveProperty:
+    def test_returns_empty_dict_when_no_setups(self):
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        with _patch_raw(ss, []):
+            assert ss.siwave == {}
+
+    def test_returns_only_siwave_setups(self):
+        stub_si = _make_setup_stub("setup_si", "si_wave")
+        stub_hfss = _make_setup_stub("setup_hfss", "hfss")
+        pedb = _make_pedb()
+
+        with patch(
+            "pyedb.grpc.database.simulation_setups.SiwaveSimulationSetup",
+            side_effect=lambda pedb, s: SimpleNamespace(name=s.name),
+        ):
+            ss = SimulationSetups(pedb)
+            with _patch_raw(ss, [stub_si, stub_hfss]):
+                result = ss.siwave
+
+        assert "setup_si" in result
+        assert "setup_hfss" not in result
+
+
+# ---------------------------------------------------------------------------
+# Property: siwave_dcir
+# ---------------------------------------------------------------------------
+
+
+class TestSiwaveDcirProperty:
+    def test_returns_empty_dict_when_no_setups(self):
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        with _patch_raw(ss, []):
+            assert ss.siwave_dcir == {}
+
+    def test_returns_only_dcir_setups(self):
+        stub_dcir = _make_setup_stub("setup_dcir", "si_wave_dcir")
+        stub_other = _make_setup_stub("setup_other", "hfss")
+        pedb = _make_pedb()
+
+        with patch(
+            "pyedb.grpc.database.simulation_setups.SIWaveDCIRSimulationSetup",
+            side_effect=lambda pedb, s: SimpleNamespace(name=s.name),
+        ):
+            ss = SimulationSetups(pedb)
+            with _patch_raw(ss, [stub_dcir, stub_other]):
+                result = ss.siwave_dcir
+
+        assert "setup_dcir" in result
+        assert "setup_other" not in result
+
+
+# ---------------------------------------------------------------------------
+# Property: raptor_x
+# ---------------------------------------------------------------------------
+
+
+class TestRaptorXProperty:
+    def test_returns_empty_dict_when_no_setups(self):
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        with _patch_raw(ss, []):
+            assert ss.raptor_x == {}
+
+    def test_returns_only_raptorx_setups(self):
+        stub_rx = _make_setup_stub("setup_rx", "raptor_x")
+        pedb = _make_pedb()
+
+        with patch(
+            "pyedb.grpc.database.simulation_setups.RaptorXSimulationSetup",
+            side_effect=lambda pedb, s: SimpleNamespace(name=s.name),
+        ):
+            ss = SimulationSetups(pedb)
+            with _patch_raw(ss, [stub_rx]):
+                result = ss.raptor_x
+
+        assert "setup_rx" in result
+
+
+# ---------------------------------------------------------------------------
+# Property: q3d
+# ---------------------------------------------------------------------------
+
+
+class TestQ3dProperty:
+    def test_returns_empty_dict_when_no_setups(self):
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        with _patch_raw(ss, []):
+            assert ss.q3d == {}
+
+    def test_returns_only_q3d_setups(self):
+        stub_q3d = _make_setup_stub("setup_q3d", "q3d_sim")
+        pedb = _make_pedb()
+
+        with patch(
+            "pyedb.grpc.database.simulation_setups.Q3DSimulationSetup",
+            side_effect=lambda pedb, s: SimpleNamespace(name=s.name),
+        ):
+            ss = SimulationSetups(pedb)
+            with _patch_raw(ss, [stub_q3d]):
+                result = ss.q3d
+
+        assert "setup_q3d" in result
+
+
+# ---------------------------------------------------------------------------
+# Property: hfss_pi
+# ---------------------------------------------------------------------------
+
+
+class TestHfsspiProperty:
+    def test_returns_empty_dict_when_no_setups(self):
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        with _patch_raw(ss, []):
+            assert ss.hfss_pi == {}
+
+    def test_returns_only_hfss_pi_setups(self):
+        stub_pi = _make_setup_stub("setup_hfss_pi", "hfss_pi")
+        stub_other = _make_setup_stub("setup_other", "hfss")
+        pedb = _make_pedb()
+
+        with patch(
+            "pyedb.grpc.database.simulation_setups.HFSSPISimulationSetup",
+            side_effect=lambda pedb, s: SimpleNamespace(name=s.name),
+        ):
+            ss = SimulationSetups(pedb)
+            with _patch_raw(ss, [stub_pi, stub_other]):
+                result = ss.hfss_pi
+
+        assert "setup_hfss_pi" in result
+        assert "setup_other" not in result
+
+    def test_ignores_none_type_setup(self):
+        stub = SimpleNamespace(name="bad", type=None)
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        with _patch_raw(ss, [stub]):
+            assert ss.hfss_pi == {}
+
+
+# ---------------------------------------------------------------------------
+# Property: siwave_cpa
+# ---------------------------------------------------------------------------
+
+
+class TestSiwaveCpaProperty:
+    def test_returns_empty_dict_when_no_cpa_name(self):
+        pedb = _make_pedb()
+        pedb.active_cell.get_product_property.return_value = SimpleNamespace(value="")
+        ss = SimulationSetups(pedb)
+        assert ss.siwave_cpa == {}
+
+    def test_creates_cpa_setup_when_name_present(self):
+        pedb = _make_pedb()
+        pedb.active_cell.get_product_property.return_value = SimpleNamespace(value="my_cpa")
+
+        fake_cpa = SimpleNamespace(name="my_cpa")
+        with patch(
+            "pyedb.grpc.database.simulation_setups.SIWaveCPASimulationSetup",
+            return_value=fake_cpa,
+        ):
+            ss = SimulationSetups(pedb)
+            result = ss.siwave_cpa
+
+        assert "my_cpa" in result
+
+    def test_does_not_duplicate_existing_cpa_setup(self):
+        pedb = _make_pedb()
+        pedb.active_cell.get_product_property.return_value = SimpleNamespace(value="my_cpa")
+
+        fake_cpa = SimpleNamespace(name="my_cpa")
+        ss = SimulationSetups(pedb)
+        ss._siwave_cpa_setup["my_cpa"] = fake_cpa
+
+        with patch(
+            "pyedb.grpc.database.simulation_setups.SIWaveCPASimulationSetup",
+        ) as mock_cpa_cls:
+            result = ss.siwave_cpa
+
+        mock_cpa_cls.assert_not_called()
+        assert "my_cpa" in result
+
+
+# ---------------------------------------------------------------------------
+# Property: setups (aggregator)
+# ---------------------------------------------------------------------------
+
+
+class TestSetupsProperty:
+    def test_merges_all_solver_dicts(self):
+        pedb = _make_pedb()
+        pedb.active_cell.get_product_property.return_value = SimpleNamespace(value="")
+        ss = SimulationSetups(pedb)
+        with _patch_raw(ss, []):
+            result = ss.setups
+        assert isinstance(result, dict)
+
+    def test_setups_contains_hfss_and_siwave(self):
+        stub_hfss = _make_setup_stub("my_hfss", "hfss")
+        stub_si = _make_setup_stub("my_si", "si_wave")
+        pedb = _make_pedb()
+        pedb.active_cell.get_product_property.return_value = SimpleNamespace(value="")
+
+        fake_hfss = SimpleNamespace(name="my_hfss")
+        fake_si = SimpleNamespace(name="my_si")
+
+        with (
+            patch(
+                "pyedb.grpc.database.simulation_setups.HfssSimulationSetup",
+                side_effect=lambda p, s: fake_hfss if s.name == "my_hfss" else None,
+            ),
+            patch(
+                "pyedb.grpc.database.simulation_setups.SiwaveSimulationSetup",
+                side_effect=lambda p, s: fake_si if s.name == "my_si" else None,
+            ),
+        ):
+            ss = SimulationSetups(pedb)
+            with _patch_raw(ss, [stub_hfss, stub_si]):
+                result = ss.setups
+
+        assert "my_hfss" in result
+        assert "my_si" in result
+
+
+# ---------------------------------------------------------------------------
+# Method: create
+# ---------------------------------------------------------------------------
+
+
+class TestCreate:
+    def _make_setup(self, name):
+        return SimpleNamespace(name=name)
+
+    def test_create_hfss_setup(self):
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        fake_setup = self._make_setup("hfss_setup")
+        with patch(
+            "pyedb.grpc.database.simulation_setups.HfssSimulationSetup.create",
+            return_value=fake_setup,
+        ):
+            result = ss.create(name="hfss_setup", solver="hfss")
+        assert result is fake_setup
+
+    def test_create_siwave_setup(self):
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        fake_setup = self._make_setup("siwave_setup")
+        with patch(
+            "pyedb.grpc.database.simulation_setups.SiwaveSimulationSetup.create",
+            return_value=fake_setup,
+        ):
+            result = ss.create(name="siwave_setup", solver="siwave")
+        assert result is fake_setup
+
+    def test_create_siwave_dcir_setup(self):
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        fake_setup = self._make_setup("dcir_setup")
+        with patch(
+            "pyedb.grpc.database.simulation_setups.SIWaveDCIRSimulationSetup.create",
+            return_value=fake_setup,
+        ):
+            result = ss.create(name="dcir_setup", solver="siwave_dcir")
+        assert result is fake_setup
+
+    def test_create_raptor_x_setup(self):
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        fake_setup = self._make_setup("rx_setup")
+        with patch(
+            "pyedb.grpc.database.simulation_setups.RaptorXSimulationSetup.create",
+            return_value=fake_setup,
+        ):
+            result = ss.create(name="rx_setup", solver="raptor_x")
+        assert result is fake_setup
+
+    def test_create_q3d_setup(self):
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        fake_setup = self._make_setup("q3d_setup")
+        with patch(
+            "pyedb.grpc.database.simulation_setups.Q3DSimulationSetup.create",
+            return_value=fake_setup,
+        ):
+            result = ss.create(name="q3d_setup", solver="q3d")
+        assert result is fake_setup
+
+    def test_create_hfss_pi_setup(self):
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        fake_setup = self._make_setup("pi_setup")
+        with patch(
+            "pyedb.grpc.database.simulation_setups.HFSSPISimulationSetup.create",
+            return_value=fake_setup,
+        ):
+            result = ss.create(name="pi_setup", solver="hfss_pi")
+        assert result is fake_setup
+
+    def test_create_falls_back_to_hfss_for_unknown_solver(self):
+        """Unknown solver should fall back to HFSS."""
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        fake_setup = self._make_setup("unknown_setup")
+        with patch(
+            "pyedb.grpc.database.simulation_setups.HfssSimulationSetup.create",
+            return_value=fake_setup,
+        ):
+            result = ss.create(name="unknown_setup", solver="not_a_solver")
+        assert result is fake_setup
+
+    def test_create_returns_none_if_name_already_exists(self):
+        """Duplicate setup name should return None and log an error."""
+        pedb = _make_pedb(existing_setups_names=["existing_setup"])
+        ss = SimulationSetups(pedb)
+        result = ss.create(name="existing_setup", solver="hfss")
+        assert result is None
+        pedb.logger.error.assert_called_once()
+
+    def test_create_auto_generates_name_when_none(self):
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        fake_setup = MagicMock()
+        with patch(
+            "pyedb.grpc.database.simulation_setups.HfssSimulationSetup.create",
+            return_value=fake_setup,
+        ):
+            result = ss.create(name=None, solver="hfss")
+        assert result is fake_setup
+
+
+# ---------------------------------------------------------------------------
+# Method: _raw_simulation_setups
+# ---------------------------------------------------------------------------
+
+
+class TestRawSimulationSetups:
+    def test_falls_back_to_public_api_when_stub_not_accessible(self):
+        """If the private Cell stub is not accessible, fall back to active_cell.simulation_setups."""
+        pedb = _make_pedb()
+        stub_hfss = _make_setup_stub("setup_hfss", "hfss")
+        # Make the private stub access raise AttributeError (simulating missing attr)
+        cell_mock = MagicMock()
+        del cell_mock._Cell__stub  # ensure attribute is missing
+        cell_mock.simulation_setups = [stub_hfss]
+        pedb.active_cell = cell_mock
+
+        ss = SimulationSetups(pedb)
+        result = ss._raw_simulation_setups()
+        assert len(result) == 1
+        assert result[0].name == "setup_hfss"
+
+    def test_falls_back_and_filters_none_from_public_api(self):
+        pedb = _make_pedb()
+        stub_hfss = _make_setup_stub("setup_hfss", "hfss")
+        cell_mock = MagicMock()
+        del cell_mock._Cell__stub
+        cell_mock.simulation_setups = [None, stub_hfss]
+        pedb.active_cell = cell_mock
+
+        ss = SimulationSetups(pedb)
+        result = ss._raw_simulation_setups()
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# Method: create_hfss_setup
+# ---------------------------------------------------------------------------
+
+
+class TestCreateHfssSetup:
+    def test_creates_without_sweep_when_freq_params_missing(self):
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        fake_setup = MagicMock()
+        fake_setup.add_sweep = MagicMock()
+        with patch.object(ss, "create", return_value=fake_setup):
+            result = ss.create_hfss_setup(name="my_hfss")
+        assert result is fake_setup
+        fake_setup.add_sweep.assert_not_called()
+
+    def test_creates_with_sweep_when_freq_params_provided(self):
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        fake_setup = MagicMock()
+        with patch.object(ss, "create", return_value=fake_setup):
+            ss.create_hfss_setup(
+                name="my_hfss",
+                start_freq=1e9,
+                stop_freq=10e9,
+                step_freq=1e8,
+            )
+        fake_setup.add_sweep.assert_called_once()
+
+    def test_applies_kwargs_as_attributes(self):
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        fake_setup = MagicMock(spec=[])
+        with patch.object(ss, "create", return_value=fake_setup):
+            ss.create_hfss_setup(name="my_hfss", my_custom_attr=42)
+        assert fake_setup.my_custom_attr == 42
+
+
+# ---------------------------------------------------------------------------
+# Method: create_hfss_pi_setup
+# ---------------------------------------------------------------------------
+
+
+class TestCreateHfsspiSetup:
+    def test_creates_without_sweep(self):
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        fake_setup = MagicMock()
+        fake_setup.add_sweep = MagicMock()
+        with patch.object(ss, "create", return_value=fake_setup):
+            result = ss.create_hfss_pi_setup(name="my_pi")
+        assert result is fake_setup
+        fake_setup.add_sweep.assert_not_called()
+
+    def test_creates_with_sweep_when_freq_params_provided(self):
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        fake_setup = MagicMock()
+        with patch.object(ss, "create", return_value=fake_setup):
+            ss.create_hfss_pi_setup(
+                name="my_pi",
+                start_freq=1e9,
+                stop_freq=5e9,
+                step_freq=1e8,
+            )
+        fake_setup.add_sweep.assert_called_once()
+
+    def test_applies_kwargs_as_attributes(self):
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        fake_setup = MagicMock(spec=[])
+        with patch.object(ss, "create", return_value=fake_setup):
+            ss.create_hfss_pi_setup(name="my_pi", extra_param="hello")
+        assert fake_setup.extra_param == "hello"
+
+
+# ---------------------------------------------------------------------------
+# Method: create_siwave_setup
+# ---------------------------------------------------------------------------
+
+
+class TestCreateSiwaveSetup:
+    def test_creates_without_sweep(self):
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        fake_setup = MagicMock()
+        fake_setup.add_sweep = MagicMock()
+        with patch.object(ss, "create", return_value=fake_setup):
+            result = ss.create_siwave_setup(name="my_si")
+        assert result is fake_setup
+        fake_setup.add_sweep.assert_not_called()
+
+    def test_creates_with_sweep_when_freq_params_provided(self):
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        fake_setup = MagicMock()
+        with patch.object(ss, "create", return_value=fake_setup):
+            ss.create_siwave_setup(
+                name="my_si",
+                start_freq=1e6,
+                stop_freq=1e9,
+                step_freq=1e6,
+            )
+        fake_setup.add_sweep.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Method: create_siwave_dcir_setup
+# ---------------------------------------------------------------------------
+
+
+class TestCreateSiwaveDcirSetup:
+    def test_creates_dcir_setup(self):
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        fake_setup = MagicMock()
+        with patch.object(ss, "create", return_value=fake_setup):
+            result = ss.create_siwave_dcir_setup(name="my_dcir")
+        assert result is fake_setup
+
+    def test_applies_kwargs_as_attributes(self):
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        fake_setup = MagicMock(spec=[])
+        with patch.object(ss, "create", return_value=fake_setup):
+            ss.create_siwave_dcir_setup(name="my_dcir", foo="bar")
+        assert fake_setup.foo == "bar"
+
+
+# ---------------------------------------------------------------------------
+# Method: create_siwave_cpa_setup
+# ---------------------------------------------------------------------------
+
+
+class TestCreateSiwaveCpaSetup:
+    def test_creates_new_cpa_setup(self):
+        pedb = _make_pedb()
+        pedb.active_cell.get_product_property.return_value = SimpleNamespace(value="")
+        ss = SimulationSetups(pedb)
+        fake_cpa = SimpleNamespace(name="my_cpa")
+
+        with patch(
+            "pyedb.grpc.database.simulation_setups.SIWaveCPASimulationSetup.create",
+            return_value=fake_cpa,
+        ):
+            result = ss.create_siwave_cpa_setup(name="my_cpa")
+
+        assert result is fake_cpa
+        assert "my_cpa" in ss._siwave_cpa_setup
+
+    def test_returns_existing_cpa_setup_if_duplicate(self):
+        pedb = _make_pedb()
+        pedb.active_cell.get_product_property.return_value = SimpleNamespace(value="")
+        ss = SimulationSetups(pedb)
+        existing = SimpleNamespace(name="existing_cpa")
+        ss._siwave_cpa_setup["existing_cpa"] = existing
+
+        with patch("pyedb.grpc.database.simulation_setups.SIWaveCPASimulationSetup.create") as mock_create:
+            result = ss.create_siwave_cpa_setup(name="existing_cpa")
+
+        mock_create.assert_not_called()
+        pedb.logger.error.assert_called_once()
+        assert result is existing
+
+    def test_auto_generates_name_when_none(self):
+        pedb = _make_pedb()
+        pedb.active_cell.get_product_property.return_value = SimpleNamespace(value="")
+        ss = SimulationSetups(pedb)
+        fake_cpa = SimpleNamespace(name="auto_name")
+
+        with patch(
+            "pyedb.grpc.database.simulation_setups.SIWaveCPASimulationSetup.create",
+            return_value=fake_cpa,
+        ):
+            result = ss.create_siwave_cpa_setup(name=None)
+
+        assert result is fake_cpa
+
+    def test_applies_kwargs_as_attributes(self):
+        pedb = _make_pedb()
+        pedb.active_cell.get_product_property.return_value = SimpleNamespace(value="")
+        ss = SimulationSetups(pedb)
+        fake_cpa = MagicMock(spec=[])
+        fake_cpa.name = "cpa_kw"
+
+        with patch(
+            "pyedb.grpc.database.simulation_setups.SIWaveCPASimulationSetup.create",
+            return_value=fake_cpa,
+        ):
+            ss.create_siwave_cpa_setup(name="cpa_kw", my_kwarg="value")
+
+        assert fake_cpa.my_kwarg == "value"
+
+
+# ---------------------------------------------------------------------------
+# Method: create_raptor_x_setup
+# ---------------------------------------------------------------------------
+
+
+class TestCreateRaptorXSetup:
+    def test_creates_without_sweep(self):
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        fake_setup = MagicMock()
+        fake_setup.add_sweep = MagicMock()
+        with patch.object(ss, "create", return_value=fake_setup):
+            result = ss.create_raptor_x_setup(name="my_rx")
+        assert result is fake_setup
+        fake_setup.add_sweep.assert_not_called()
+
+    def test_creates_with_sweep_when_freq_params_provided(self):
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        fake_setup = MagicMock()
+        with patch.object(ss, "create", return_value=fake_setup):
+            ss.create_raptor_x_setup(
+                name="my_rx",
+                start_freq=0,  # 0 is a valid start; condition checks `is not None`
+                stop_freq=10e9,
+                step_freq=1e8,
+            )
+        fake_setup.add_sweep.assert_called_once()
+
+    def test_no_sweep_when_stop_freq_missing(self):
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        fake_setup = MagicMock()
+        fake_setup.add_sweep = MagicMock()
+        with patch.object(ss, "create", return_value=fake_setup):
+            ss.create_raptor_x_setup(name="my_rx", start_freq=1e9)
+        fake_setup.add_sweep.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Method: create_q3d_setup
+# ---------------------------------------------------------------------------
+
+
+class TestCreateQ3dSetup:
+    def test_creates_without_sweep(self):
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        fake_setup = MagicMock()
+        fake_setup.add_sweep = MagicMock()
+        with patch.object(ss, "create", return_value=fake_setup):
+            result = ss.create_q3d_setup(name="my_q3d")
+        assert result is fake_setup
+        fake_setup.add_sweep.assert_not_called()
+
+    def test_creates_with_sweep_when_freq_params_provided(self):
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        fake_setup = MagicMock()
+        with patch.object(ss, "create", return_value=fake_setup):
+            ss.create_q3d_setup(
+                name="my_q3d",
+                start_freq=1e9,
+                stop_freq=10e9,
+                step_freq=1e8,
+            )
+        fake_setup.add_sweep.assert_called_once()
+
+    def test_applies_kwargs_as_attributes(self):
+        pedb = _make_pedb()
+        ss = SimulationSetups(pedb)
+        fake_setup = MagicMock(spec=[])
+        with patch.object(ss, "create", return_value=fake_setup):
+            ss.create_q3d_setup(name="my_q3d", custom_opt=True)
+        assert fake_setup.custom_opt is True


### PR DESCRIPTION
This PR is addressing a work around to resolve a bug in ansys-edb-core where setup.cast() returns always None for HFSS-PI simulation setup. 
This PR is also increasing code coverage for simulation setup.

closes #2200 