### PR TITLE
FIX: issue #2214 fixed

### DIFF
--- a/doc/changelog.d/2215.fixed.md
+++ b/doc/changelog.d/2215.fixed.md
@@ -1,0 +1,1 @@
+Issue #2214 fixed

--- a/src/pyedb/configuration/cfg_stackup.py
+++ b/src/pyedb/configuration/cfg_stackup.py
@@ -27,7 +27,7 @@ materials, layers, roughness, and etching definitions.
 
 from typing import Any, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import AliasChoices, BaseModel, Field
 
 
 class CfgMaterialPropertyThermalModifier(BaseModel):
@@ -111,7 +111,11 @@ class CfgLayer(BaseModel):
     """Represent one signal or dielectric layer entry."""
 
     name: Optional[str] = None
-    layer_type: Optional[str] = Field("signal", alias="type")
+    layer_type: Optional[str] = Field(
+        "signal",
+        validation_alias=AliasChoices("layer_type", "type"),
+        serialization_alias="type",
+    )
     material: Optional[str] = None
     fill_material: Optional[str] = None
     thickness: Optional[float | int | str] = None

--- a/src/pyedb/configuration/configuration.py
+++ b/src/pyedb/configuration/configuration.py
@@ -842,7 +842,7 @@ class Configuration:
         layers_ = list()
         layers_.extend(self.cfg_data.stackup.layers)
         for l_attrs in layers_:
-            attrs = l_attrs.model_dump(exclude_none=True, by_alias=True)
+            attrs = l_attrs.model_dump(exclude_none=True, by_alias=False)
             self._pedb.stackup.add_layer_bottom(**attrs)
 
     def __update_stackup(self):
@@ -880,7 +880,7 @@ class Configuration:
             if l.type == "signal":
                 layer_id = lc_signal_layers[signal_idx]
                 layer_name = id_name[layer_id]
-                attrs = l.model_dump(exclude_none=True, by_alias=True)
+                attrs = l.model_dump(exclude_none=True, by_alias=False)
                 self._pedb.stackup.layers[layer_name].update(**attrs)
                 signal_idx = signal_idx + 1
 
@@ -890,11 +890,11 @@ class Configuration:
         if l.type == "signal":
             prev_layer_clone = self._pedb.stackup.layers[l.name]
         else:
-            attrs = l.model_dump(exclude_none=True, by_alias=True)
+            attrs = l.model_dump(exclude_none=True, by_alias=False)
             prev_layer_clone = self._pedb.stackup.add_layer_top(**attrs)
         for idx, l in enumerate(layers):
             if l.type == "dielectric":
-                attrs = l.model_dump(exclude_none=True, by_alias=True)
+                attrs = l.model_dump(exclude_none=True, by_alias=False)
                 prev_layer_clone = self._pedb.stackup.add_layer_below(base_layer_name=prev_layer_clone.name, **attrs)
             elif l.type == "signal":
                 prev_layer_clone = self._pedb.stackup.layers[l.name]

--- a/src/pyedb/grpc/database/layers/stackup_layer.py
+++ b/src/pyedb/grpc/database/layers/stackup_layer.py
@@ -119,6 +119,9 @@ class StackupLayer:
             self.core.type = value
 
     def update(self, **kwargs):
+        # Normalise layer_type (Python field name) to type (property name on this object)
+        if "layer_type" in kwargs and "type" not in kwargs:
+            kwargs["type"] = kwargs.pop("layer_type")
         for k, v in kwargs.items():
             if k in dir(self):
                 self.__setattr__(k, v)

--- a/src/pyedb/grpc/database/stackup.py
+++ b/src/pyedb/grpc/database/stackup.py
@@ -160,14 +160,19 @@ class LayerCollection:
         if "thickness" in kwargs:
             thickness = self._pedb._value_setter(kwargs["thickness"])
         elevation = 0.0
+        if "type" in kwargs:
+            layer_type = kwargs["type"]
+        material = kwargs.get("material", "copper")
         layer = StackupLayer.create(
             layout=self._pedb.layout,
             name=name,
             layer_type=layer_type,
             thickness=thickness,
-            material="copper",
+            material=material,
             elevation=elevation,
         )
+        if "fill_material" in kwargs:
+            layer.core.set_fill_material(kwargs["fill_material"])
         return self.core.add_layer_top(layer.core)
 
     def add_layer_bottom(self, name: str, layer_type: str = "signal", **kwargs) -> Union["Layer", None]:
@@ -269,6 +274,8 @@ class LayerCollection:
             material=material,
             elevation=elevation,
         )
+        if "fill_material" in kwargs:
+            layer.core.set_fill_material(kwargs["fill_material"])
         return self.core.add_layer_below(layer.core, base_layer_name)
 
     def add_layer_above(


### PR DESCRIPTION
This PR is fixing issue #2214 

Problem
When applying a stackup configuration JSON that starts with a dielectric layer (e.g. RESIST-A), the layer was incorrectly created as a signal layer with copper material assigned, instead of the specified dielectric type and material.
Two bugs combined to produce this behavior:
1- LayerCollection.add_layer_top ignored type and hardcoded material — the method never read kwargs["type"] to override its layer_type parameter, and always passed material="copper" to StackupLayer.create, ignoring any material supplied by the caller.

2- CfgLayer.layer_type used alias="type" causing a kwarg name mismatch — model_dump(by_alias=True) serialized the field as "type", but the stackup methods declare a layer_type named parameter. Because "type" is not a named parameter, it silently fell into **kwargs and was never picked up, so layer_type always defaulted to "signal".

Backward compatibility
All existing JSON configuration files using "type": "signal" / "type": "dielectric" continue to parse and serialize without change.
Public Python API (add_signal_layer, add_dielectric_layer, add_layer, add_layer_top, etc.) is unchanged.

closes #2214 