### PR TITLE
FIX: CI activation for Windows virtual environment

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -250,12 +250,12 @@ jobs:
           retry_on: error
           timeout_minutes: 120
           command: |
-            source .venv/bin/activate
+            .venv\Scripts\activate
             pytest tests/system -vvv --cov
 
       - name: Create coverage files
         run: |
-          source .venv/bin/activate
+          .venv\Scripts\activate
           python -m coverage html -d .cov\system-html
           python -m coverage xml -o .cov\system.xml
 
@@ -312,12 +312,12 @@ jobs:
           retry_on: error
           timeout_minutes: 180
           command: |
-            source .venv/bin/activate
+            .venv\Scripts\activate
             pytest tests/system -vvv --cov
 
       - name: Create coverage files
         run: |
-          source .venv/bin/activate
+          .venv\Scripts\activate
           python -m coverage html -d .cov\system-html
           python -m coverage xml -o .cov\system.xml
 
@@ -529,7 +529,7 @@ jobs:
           retry_on: error
           timeout_minutes: 180
           command: |
-            source .venv/bin/activate
+            .venv\Scripts\activate
             pytest -v external/pyaedt/tests/system/layout/test_3dlayout_edb.py
             pytest -v external/pyaedt/tests/system/layout/test_3dlayout_modeler.py
             pytest -v external/pyaedt/tests/system/general/test_configuration_files.py
@@ -547,7 +547,7 @@ jobs:
           retry_on: error
           timeout_minutes: 180
           command: |
-            source .venv/bin/activate
+            .venv\Scripts\activate
             pytest -v external/pyaedt/tests/system/solvers/test_analyze.py
 
       - name: Run PyAEDT extensions tests
@@ -560,7 +560,7 @@ jobs:
           retry_on: error
           timeout_minutes: 180
           command: |
-            source .venv/bin/activate
+            .venv\Scripts\activate
             pytest -v external/pyaedt/tests/system/extensions/test_cutout.py
             pytest -v external/pyaedt/tests/system/extensions/test_configure_layout.py
             pytest -v external/pyaedt/tests/system/extensions/test_via_design.py
@@ -637,7 +637,6 @@ jobs:
           retry_on: error
           timeout_minutes: 180
           command: |
-
             source .venv/bin/activate
             pytest -v external/pyaedt/tests/system/layout/test_3dlayout_edb.py
             pytest -v external/pyaedt/tests/system/layout/test_3dlayout_modeler.py

--- a/doc/changelog.d/2238.fixed.md
+++ b/doc/changelog.d/2238.fixed.md
@@ -1,0 +1,1 @@
+CI activation for Windows virtual environment


### PR DESCRIPTION
Update the activation command for the virtual environment to be compatible with Windows. This change ensures that the CI pipeline can successfully activate the virtual environment and run tests.