### PR TITLE
FIX: vertical edge port reference layer failing

### DIFF
--- a/doc/changelog.d/2244.fixed.md
+++ b/doc/changelog.d/2244.fixed.md
@@ -1,0 +1,1 @@
+Vertical edge port reference layer failing

--- a/src/pyedb/grpc/database/source_excitations.py
+++ b/src/pyedb/grpc/database/source_excitations.py
@@ -2282,7 +2282,9 @@ class SourceExcitation(SourceExcitationInternal):
         pos_edge_term = self._create_edge_terminal(prim_id, point_on_edge, port_name)
         pos_edge_term.impedance = self._pedb._value_setter(impedance)
         if reference_layer:
-            reference_layer = self._pedb.stackup.signal_layers[reference_layer]
+            if reference_layer not in self._pedb.stackup.signal_layers:
+                self._pedb.logger.error(f"Reference layer '{reference_layer}' not found in signal layers.")
+                return None
             pos_edge_term.reference_layer = reference_layer
         prop = ", ".join(
             [

--- a/src/pyedb/grpc/database/terminal/edge_terminal.py
+++ b/src/pyedb/grpc/database/terminal/edge_terminal.py
@@ -83,6 +83,38 @@ class EdgeTerminal(Terminal):
         return Component(self._pedb, self.core.component)
 
     @property
+    def reference_layer(self):
+        """Reference layer of the terminal.
+
+        Returns
+        -------
+        str or None
+            Name of the reference layer, or ``None`` if not set.
+        """
+        try:
+            layer = self.core.reference_layer
+            return layer.name if layer and not layer.is_null else None
+        except AttributeError:
+            return None
+
+    @reference_layer.setter
+    def reference_layer(self, value):
+        """Set the reference layer of the terminal.
+
+        Parameters
+        ----------
+        value : str, :class:`StackupLayer <pyedb.grpc.database.layers.stackup_layer.StackupLayer>`, or gRPC Layer
+            Reference layer name, pyedb StackupLayer wrapper, or raw gRPC Layer object.
+        """
+        from pyedb.grpc.database.layers.stackup_layer import StackupLayer
+
+        if isinstance(value, StackupLayer):
+            self.core.reference_layer = value.core
+        else:
+            # Accepts a string (layer name) or a raw gRPC Layer object directly.
+            self.core.reference_layer = value
+
+    @property
     def is_circuit_port(self) -> bool:
         """Is circuit port.
 

--- a/tests/unit/test_ports.py
+++ b/tests/unit/test_ports.py
@@ -468,3 +468,91 @@ class TestNormalizeNetListEdgeCases:
     def test_non_string_non_net_ignored(self):
         result = SourceExcitationInternal._normalize_net_list([123, None, "GND"])
         assert result == {"GND"}
+
+
+def _make_excitation_for_edge_port():
+    """Build a SourceExcitation with the _create_edge_terminal and stackup mocked."""
+    exc, pedb = _make_excitation()
+
+    # Mock the edge terminal returned by _create_edge_terminal
+    mock_term = MagicMock()
+    mock_term.is_null = False
+    mock_term.name = "P1"
+    exc._create_edge_terminal = MagicMock(return_value=mock_term)
+
+    # Mock _value_setter so impedance assignment doesn't crash
+    pedb._value_setter = MagicMock(return_value=50)
+
+    # Mock set_product_solver_option on the terminal
+    mock_term.set_product_solver_option = MagicMock()
+
+    return exc, pedb, mock_term
+
+
+@pytest.mark.grpc
+class TestCreateEdgePortVerticalReferenceLayer:
+    """Regression tests – create_edge_port_vertical must not raise when reference_layer is specified."""
+
+    def test_no_reference_layer_succeeds(self):
+        """Without reference_layer the method returns the port name without touching reference_layer."""
+        exc, pedb, mock_term = _make_excitation_for_edge_port()
+        # signal_layers not consulted when reference_layer is None
+        result = exc.create_edge_port_vertical(
+            prim_id=1,
+            point_on_edge=[0.0, 0.5e-3],
+            port_name="P1",
+        )
+        assert result == "P1"
+        # stackup.signal_layers should not have been accessed at all
+        pedb.stackup.signal_layers.__contains__.assert_not_called()
+
+    def test_valid_reference_layer_sets_terminal_reference_layer(self):
+        """With a valid reference_layer string the setter is called on the terminal."""
+        exc, pedb, mock_term = _make_excitation_for_edge_port()
+
+        # Simulate the layer existing in signal_layers
+        mock_stackup_layer = MagicMock()
+        pedb.stackup.signal_layers = {"L2_BOT": mock_stackup_layer}
+
+        result = exc.create_edge_port_vertical(
+            prim_id=1,
+            point_on_edge=[0.0, 0.5e-3],
+            port_name="P1",
+            reference_layer="L2_BOT",
+        )
+
+        assert result == "P1"
+        # Verify that reference_layer was assigned on the terminal mock
+        assert mock_term.reference_layer == "L2_BOT"
+
+    def test_invalid_reference_layer_returns_none_and_logs_error(self):
+        """With a reference_layer that does not exist the method returns None and logs an error."""
+        exc, pedb, mock_term = _make_excitation_for_edge_port()
+
+        # Layer NOT present in signal_layers
+        pedb.stackup.signal_layers = {}
+
+        result = exc.create_edge_port_vertical(
+            prim_id=1,
+            point_on_edge=[0.0, 0.5e-3],
+            port_name="P1",
+            reference_layer="NONEXISTENT",
+        )
+
+        assert result is None
+        pedb.logger.error.assert_called_once()
+
+    def test_reference_layer_not_assigned_when_layer_missing(self):
+        """When reference_layer is invalid the method returns None (exits before assigning reference_layer)."""
+        exc, pedb, mock_term = _make_excitation_for_edge_port()
+        pedb.stackup.signal_layers = {}
+
+        result = exc.create_edge_port_vertical(
+            prim_id=1,
+            point_on_edge=[0.0, 0.5e-3],
+            port_name="P1",
+            reference_layer="BAD_LAYER",
+        )
+
+        # Early exit means None is returned; the terminal name is never reached
+        assert result is None

--- a/tests/unit/test_variables_and_terminal.py
+++ b/tests/unit/test_variables_and_terminal.py
@@ -294,3 +294,81 @@ class TestGrpcTerminalUnit:
         result = terminal.reference_layer
         pedb.logger.error.assert_called_once()
         assert result is None
+
+
+def _make_edge_terminal():
+    """Return an EdgeTerminal instance with mocked pedb and core."""
+    from pyedb.grpc.database.terminal.edge_terminal import EdgeTerminal
+
+    pedb = MagicMock()
+    pedb.logger = MagicMock()
+    core = MagicMock()
+    core.is_null = False
+    terminal = EdgeTerminal.__new__(EdgeTerminal)
+    terminal._pedb = pedb
+    terminal.core = core
+    terminal._reference_object = None
+    terminal._hfss_type = "Gap"
+    return terminal
+
+
+@pytest.mark.grpc
+class TestEdgeTerminalReferenceLayer:
+    """Tests for EdgeTerminal.reference_layer getter and setter (regression for create_edge_port_vertical bug)."""
+
+    def test_getter_returns_layer_name(self):
+        """reference_layer getter returns the layer name from core."""
+        term = _make_edge_terminal()
+        mock_layer = MagicMock()
+        mock_layer.is_null = False
+        mock_layer.name = "L2_BOT"
+        term.core.reference_layer = mock_layer
+
+        assert term.reference_layer == "L2_BOT"
+
+    def test_getter_returns_none_when_layer_is_null(self):
+        """reference_layer getter returns None when the core layer is null."""
+        term = _make_edge_terminal()
+        mock_layer = MagicMock()
+        mock_layer.is_null = True
+        term.core.reference_layer = mock_layer
+
+        assert term.reference_layer is None
+
+    def test_getter_returns_none_on_attribute_error(self):
+        """reference_layer getter returns None gracefully when core raises AttributeError."""
+        term = _make_edge_terminal()
+        type(term.core).reference_layer = property(lambda self: (_ for _ in ()).throw(AttributeError("no layer")))
+
+        assert term.reference_layer is None
+
+    def test_setter_with_stackup_layer_passes_core(self):
+        """Setting reference_layer with a StackupLayer passes its .core to the gRPC terminal."""
+        from pyedb.grpc.database.layers.stackup_layer import StackupLayer
+
+        term = _make_edge_terminal()
+        grpc_layer = MagicMock()
+        stackup_layer = StackupLayer.__new__(StackupLayer)
+        stackup_layer.core = grpc_layer
+        stackup_layer._pedb = term._pedb
+
+        term.reference_layer = stackup_layer
+
+        assert term.core.reference_layer == grpc_layer
+
+    def test_setter_with_string_passes_string(self):
+        """Setting reference_layer with a string passes the string directly to the gRPC terminal."""
+        term = _make_edge_terminal()
+
+        term.reference_layer = "L2_BOT"
+
+        assert term.core.reference_layer == "L2_BOT"
+
+    def test_setter_with_grpc_layer_passes_directly(self):
+        """Setting reference_layer with a raw gRPC Layer passes it directly to the gRPC terminal."""
+        term = _make_edge_terminal()
+        grpc_layer = MagicMock()
+
+        term.reference_layer = grpc_layer
+
+        assert term.core.reference_layer == grpc_layer


### PR DESCRIPTION
This PR as resolving issue #2017 where using vertical edge port and adding reference layer was failing on gRPC.

closes #2017 