### PR TITLE
REFACTOR: remove redundant methods in gRPC

### DIFF
--- a/doc/changelog.d/2254.miscellaneous.md
+++ b/doc/changelog.d/2254.miscellaneous.md
@@ -1,0 +1,1 @@
+Remove redundant methods in gRPC

--- a/src/pyedb/configuration/cfg_package_definition.py
+++ b/src/pyedb/configuration/cfg_package_definition.py
@@ -150,7 +150,7 @@ class CfgPackageDefinitions:
         package_definitions = []
         _pkg_field_names = set(CfgPackage.model_fields.keys())
         _hs_field_names = set(CfgHeatSink.model_fields.keys())
-        for pkg_name, pkg_obj in self._pedb.definitions.package.items():
+        for pkg_name, pkg_obj in self._pedb.definitions.packages.items():
             pkg = {}
             pkg_attrs = [i for i in dir(pkg_obj) if not i.startswith("_")]
             pkg_attrs = {i for i in pkg_attrs if i in _pkg_field_names}
@@ -176,8 +176,8 @@ class CfgPackageDefinitions:
             from pyedb.dotnet.database.definition.package_def import PackageDef
 
         for pkg in self.packages:
-            comp_def_from_db = self._pedb.definitions.component[pkg.component_definition]
-            if pkg.name in self._pedb.definitions.package:
+            comp_def_from_db = self._pedb.definitions.components[pkg.component_definition]
+            if pkg.name in self._pedb.definitions.packages:
                 self._pedb.definitions.package[pkg.name].delete()
 
             if pkg.extent_bounding_box:

--- a/src/pyedb/configuration/cfg_s_parameter_models.py
+++ b/src/pyedb/configuration/cfg_s_parameter_models.py
@@ -84,7 +84,7 @@ class CfgSParameters:
         """Read S-parameter model assignments from EDB."""
         if self._pedb is None:
             return [m.model_dump() for m in self.models]
-        db_comp_def = self._pedb.definitions.component
+        db_comp_def = self._pedb.definitions.components
         for name, compdef_obj in db_comp_def.items():
             nport_models = compdef_obj.component_models
             if not nport_models:

--- a/src/pyedb/grpc/database/definitions.py
+++ b/src/pyedb/grpc/database/definitions.py
@@ -35,72 +35,6 @@ class Definitions:
         self._pedb = pedb
 
     @property
-    @deprecated_property("use components property instead")
-    def component_defs(self) -> Dict[str, ComponentDef]:
-        """Component definitions.
-
-        .. deprecated:: 0.66.0
-           Use :attr:`components` instead.
-
-        """
-        return self.components
-
-    @property
-    @deprecated_property("use components property instead")
-    def component(self):
-        """Component definitions.
-
-        .. deprecated:: 0.66.0
-           Use :attr:`components` instead.
-
-        """
-        return self.components
-
-    @property
-    @deprecated_property("use apd_bondwires property instead")
-    def apd_bondwire_defs(self):
-        """Get all APD bondwire definitions in this Database.
-
-        .. deprecated:: 0.66.0
-           Use :attr:`apd_bondwires` instead.
-
-        """
-        return self.apd_bondwires
-
-    @property
-    @deprecated_property("use jedec4_bondwires property instead")
-    def jedec4_bondwire_defs(self):
-        """Get all JEDEC4 bondwire definitions in this Database.
-
-        .. deprecated:: 0.66.0
-           Use :attr:`jedec4_bondwires` instead.
-
-        """
-        return self.jedec4_bondwires
-
-    @property
-    @deprecated_property("use jedec5_bondwires property instead")
-    def jedec5_bondwire_defs(self):
-        """Get all JEDEC5 bondwire definitions in this Database.
-
-        .. deprecated:: 0.66.0
-           Use :attr:`jedec5_bondwires` instead.
-
-        """
-        return self.jedec5_bondwires
-
-    @property
-    @deprecated_property("use packages property instead")
-    def package_defs(self) -> Dict[str, PackageDef]:
-        """Package definitions.
-
-        .. deprecated:: 0.66.0
-           Use :attr:`packages` instead.
-
-        """
-        return self.packages
-
-    @property
     def components(self) -> Dict[str, ComponentDef]:
         """Component definitions
 
@@ -113,17 +47,6 @@ class Definitions:
         ...     print(f"Component: {name}, Part: {comp_def.part}")
         """
         return {l.name: ComponentDef(self._pedb, l) for l in self._pedb.active_db.component_defs}
-
-    @property
-    @deprecated_property("use packages property instead")
-    def package(self):
-        """Package definitions.
-
-        .. deprecated:: 0.66.0
-           Use :attr:`packages` instead.
-
-        """
-        return self.packages
 
     @property
     def packages(self) -> Dict[str, PackageDef]:
@@ -183,19 +106,6 @@ class Definitions:
             jedec5_def.name.value: Jedec5BondwireDef(self._pedb, jedec5_def)
             for jedec5_def in self._pedb.active_db.jedec5_bondwire_defs
         }
-
-    @deprecated("use add_package() method instead")
-    def add_package_def(
-        self, name: str, component_part_name: Optional[str] = None, boundary_points: Optional[List[List[float]]] = None
-    ) -> Union[PackageDef, bool]:
-        """Add a package definition.
-
-        .. deprecated:: 0.66.0
-
-           Use :meth:`add_package` instead.
-
-        """
-        return self.add_package(name, component_part_name=component_part_name, boundary_points=boundary_points)
 
     def add_package(
         self, name: str, component_part_name: Optional[str] = None, boundary_points: Optional[List[List[float]]] = None

--- a/tests/unit/tests_configuration/test_cfg_s_parameters.py
+++ b/tests/unit/tests_configuration/test_cfg_s_parameters.py
@@ -205,7 +205,7 @@ class TestCfgSParameters:
         mock_comp_def.component_models = {"m1": mock_model_obj}
         mock_comp_def.get_properties.return_value = {"pin_order": None}
         mock_pedb = MagicMock()
-        mock_pedb.definitions.component = {"CAP": mock_comp_def}
+        mock_pedb.definitions.components = {"CAP": mock_comp_def}
         sc = CfgSParameters(pedb=mock_pedb)
         cfg_components = [
             {


### PR DESCRIPTION
The removed methods do exist in dotnet. They are never exposed to customers before gRPC, so they should not exist.