### PR TITLE
CI: Remove reviewers and add pre-commit in dependabot cfg

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@ pyproject.toml @ecoussoux-ansys
 
 
 # These owners will be the default owners for everything in the repo.
-* @svandenb-dev @ring630 @maxcapodi78 @SMoraisAnsys @Samuelopez-ansys
+* @svandenb-dev @hui-zhou-a @maxcapodi78 @SMoraisAnsys @Samuelopez-ansys

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "pip" # See documentation for possible values
+  - package-ecosystem: "uv" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
@@ -12,15 +12,14 @@ updates:
         - "ansys-sphinx-theme"
         - "ansys-tools-visualization-interface"
         - "ansys-pythonnet"
-    reviewers:
-      - "SMoraisAnsys"
     assignees:
-      - "pyansys-ci-bot"
+      - "svandenb-dev"
+      - "hui-zhou-a"
     labels:
       - "maintenance"
       - "dependencies"
     commit-message:
-      prefix: "BUILD"
+      prefix: "BUILD(uv)"
 
   - package-ecosystem: "github-actions"
     cooldown:
@@ -28,12 +27,33 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    reviewers:
-      - "SMoraisAnsys"
     assignees:
-      - "pyansys-ci-bot"
+      - "svandenb-dev"
+      - "hui-zhou-a"
     labels:
       - "maintenance"
       - "dependencies"
     commit-message:
-      prefix: "BUILD"
+      prefix: "BUILD(actions)"
+
+  - package-ecosystem: "pre-commit"
+    cooldown:
+      default-days: 7 # Fallback cooldown if no specific rule applies
+      include:
+        - "*"  # Include all dependencies in cooldown
+      exclude:
+        - "ansys/pre-commit-hooks"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "06:00"
+      timezone: "Europe/Paris"
+    assignees:
+      - "svandenb-dev"
+      - "hui-zhou-a"
+    labels:
+      - "maintenance"
+      - "dependencies"
+    commit-message:
+      prefix: "BUILD(pre-commit)"

--- a/doc/changelog.d/2268.maintenance.md
+++ b/doc/changelog.d/2268.maintenance.md
@@ -1,0 +1,1 @@
+Remove reviewers and add pre-commit in dependabot cfg


### PR DESCRIPTION
More than a year ago, dependabot asked maintainers to mainly leverage CODEOWNERS instead, see [this link](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/) for the associated changelog. This PR removes that configuration and add pre-commit eco system.

closes #2260 