### PR TITLE
CHORE: removing failing tests on pyaedt linux

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -615,7 +615,6 @@ jobs:
           source .venv/bin/activate
           pytest -v external/pyaedt/tests/system/layout/test_3dlayout_edb.py
           pytest -v external/pyaedt/tests/system/layout/test_3dlayout_modeler.py
-          pytest -v external/pyaedt/tests/system/general/test_configuration_files.py
           pytest -v external/pyaedt/tests/system/general/test_primitives_3d.py::test_insert_layout_component
           pytest -v external/pyaedt/tests/system/general/test_hfss.py::test_import_dxf
         timeout-minutes: 180

--- a/doc/changelog.d/2283.maintenance.md
+++ b/doc/changelog.d/2283.maintenance.md
@@ -1,0 +1,1 @@
+Removing failing tests on pyaedt linux


### PR DESCRIPTION
This PR is removing failing tests in PyAEDT main branch under Linux introduced with SP2. This is located at product level therefore not related to python code.