### PR TITLE
FIX: rpc fast mode detection fixed

### DIFF
--- a/doc/changelog.d/2301.fixed.md
+++ b/doc/changelog.d/2301.fixed.md
@@ -1,0 +1,1 @@
+Rpc fast mode detection fixed

--- a/src/pyedb/grpc/rpc_session.py
+++ b/src/pyedb/grpc/rpc_session.py
@@ -199,8 +199,8 @@ class RpcSession:
         for attempt in range(max_attempts):
             try:
                 RpcSession.rpc_session = launch_session(RpcSession.base_path, port_num=RpcSession.port)
-                if hasattr(RpcSession.rpc_session, "in_memory"):
-                    RpcSession.fast_grpc_mode_enabled = RpcSession.rpc_session.in_memory
+                if hasattr(RpcSession.rpc_session, "shared_memory"):
+                    RpcSession.fast_grpc_mode_enabled = RpcSession.rpc_session.shared_memory
                 else:
                     RpcSession.fast_grpc_mode_enabled = False
                 break


### PR DESCRIPTION
This PR is fixing fast mode detection correctly. Previously fast mode was enabled but log message was saying the opposite. 

closes #2302