### PR TITLE
FIX: edb version defaulting to latest installed 

### DIFF
--- a/doc/changelog.d/2335.fixed.md
+++ b/doc/changelog.d/2335.fixed.md
@@ -1,0 +1,1 @@
+Edb version defaulting to latest installed

--- a/src/pyedb/generic/general_methods.py
+++ b/src/pyedb/generic/general_methods.py
@@ -46,7 +46,6 @@ from pyedb.generic.settings import settings
 
 # Backwards-compatible re-exports (decorators were moved to pyedb.misc.decorators)
 from pyedb.misc.decorators import deprecate_argument_name, deprecated, deprecated_class, execution_timer
-from pyedb.misc.misc import list_installed_ansysem
 
 if TYPE_CHECKING:
     import pandas as pd

--- a/src/pyedb/generic/general_methods.py
+++ b/src/pyedb/generic/general_methods.py
@@ -134,8 +134,7 @@ def env_path(input_version: str) -> str:
     """
     try:
         if input_version is None:
-            installed_version = list_installed_ansysem()[0]
-            return os.getenv(installed_version)
+            return list(settings.INSTALLED_VERSIONS.values())[0]
         else:
             return os.getenv(
                 "ANSYSEM_ROOT{0}{1}".format(

--- a/src/pyedb/generic/general_methods.py
+++ b/src/pyedb/generic/general_methods.py
@@ -46,6 +46,7 @@ from pyedb.generic.settings import settings
 
 # Backwards-compatible re-exports (decorators were moved to pyedb.misc.decorators)
 from pyedb.misc.decorators import deprecate_argument_name, deprecated, deprecated_class, execution_timer
+from pyedb.misc.misc import list_installed_ansysem
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -132,12 +133,16 @@ def env_path(input_version: str) -> str:
     "C:/Program Files/ANSYSEM/ANSYSEM2021.2/Win64"
     """
     try:
-        return os.getenv(
-            "ANSYSEM_ROOT{0}{1}".format(
-                get_version_and_release(input_version)[0], get_version_and_release(input_version)[1]
-            ),
-            "",
-        )
+        if input_version is None:
+            installed_version = list_installed_ansysem()[0]
+            return os.getenv(installed_version)
+        else:
+            return os.getenv(
+                "ANSYSEM_ROOT{0}{1}".format(
+                    get_version_and_release(input_version)[0], get_version_and_release(input_version)[1]
+                ),
+                "",
+            )
     except TypeError as e:
         raise Exception(
             "The edb version is not provided and can't be inferred from the environment variables. "
@@ -165,7 +170,7 @@ def get_version_and_release(input_version: str) -> tuple[int, int]:
             version -= 1
         else:
             release -= 2
-    return (version, release)
+    return version, release
 
 
 def env_value(input_version: str) -> str:

--- a/src/pyedb/generic/general_methods.py
+++ b/src/pyedb/generic/general_methods.py
@@ -133,18 +133,14 @@ def env_path(input_version: str) -> str:
     """
     try:
         if input_version is None:
-            return list(settings.INSTALLED_VERSIONS.values())[0]
+            return settings.aedt_installation_path
+        elif input_version in settings.INSTALLED_VERSIONS:
+            return settings.INSTALLED_VERSIONS[input_version]
         else:
-            return os.getenv(
-                "ANSYSEM_ROOT{0}{1}".format(
-                    get_version_and_release(input_version)[0], get_version_and_release(input_version)[1]
-                ),
-                "",
-            )
+            raise ValueError(f"Invalid or not found AEDT version {input_version}")
     except TypeError as e:
         raise Exception(
-            "The edb version is not provided and can't be inferred from the environment variables. "
-            "Please provide the version as an argument."
+            f"Failed to retrieve the installation path for the specified AEDT version {input_version}."
         ) from e
 
 


### PR DESCRIPTION
When version=None the current pyedb version throw an error in grpc. In order to bring consistency with DotNet, this PR is addressing issue #2333, so latest found installation version is taking by default if None is provided.

closes #2333 