### PR TITLE
FEAT: exterior_boundary_with_arcs support

### DIFF
--- a/doc/changelog.d/2337.added.md
+++ b/doc/changelog.d/2337.added.md
@@ -1,0 +1,1 @@
+Exterior_boundary_with_arcs support

--- a/src/pyedb/grpc/database/definition/package_def.py
+++ b/src/pyedb/grpc/database/definition/package_def.py
@@ -109,9 +109,26 @@ class PackageDef:
         Returns
         -------
         :class:`PolygonData <class: PolygonData>`
+            return boundary without arcs e.g. arcs are discretized instead.
 
         """
         return PolygonData(self._pedb, self.core.exterior_boundary.without_arcs())
+
+    @property
+    def exterior_boundary_with_arcs(self) -> PolygonData:
+        """Get the exterior boundary of a package definition with arcs if exists.
+
+        Returns
+        -------
+        :class:`PolygonData <class: PolygonData>`
+            return boundary without arcs if exists.
+
+        Note
+        ----
+        This property does not have setter just use `exterior_boundary` setter.
+
+        """
+        return PolygonData(self._pedb, self.core.exterior_boundary)
 
     @exterior_boundary.setter
     def exterior_boundary(self, value):

--- a/tests/system/test_edb_components.py
+++ b/tests/system/test_edb_components.py
@@ -554,6 +554,7 @@ class TestClass(BaseTestClass):
             assert not pkg_def.exterior_boundary.points
             assert pkg_def.set_exterior_boundary_from_bbox("C200")
             assert len(pkg_def.exterior_boundary.points) == 4
+            assert len(pkg_def.exterior_boundary_with_arcs.arcs) == 4
             assert pkg_def.set_exterior_boundary_from_bbox(edb.components.instances["C200"])
         edb.close(terminate_rpc_session=False)
 


### PR DESCRIPTION
This PR is adding PackageDef exterior boundary with arcs support following issue #2294 

closes #2294 