### PR TITLE
FIX: solder balls silent failure on IC component fix

### DIFF
--- a/doc/changelog.d/2358.fixed.md
+++ b/doc/changelog.d/2358.fixed.md
@@ -1,0 +1,1 @@
+Solder balls silent failure on IC component fix

--- a/src/pyedb/grpc/database/components.py
+++ b/src/pyedb/grpc/database/components.py
@@ -1345,16 +1345,10 @@ class Components(object):
             # ansys-edb-core typed component property (ICComponentProperty / IOComponentProperty).
             #
             # ansys-edb-core issue: ComponentGroup.component_property returns a *reference* to
+            # issue #752 amd #753
             # the live property object.  Calling SetComponentProperty with the same reference is
             # treated as a no-op by the server and the changes are silently lost on save.  The
-            # fix (mirroring the dotnet pattern of GetComponentProperty().Clone()) is to:
-            #   1. Fetch the live reference and mutate its sub-properties via the typed setters
-            #      (SetDieProperty / SetSolderBallProperty / SetPortProperty) so those changes
-            #      are in the server-side buffer.
-            #   2. Clone the reference AFTER all mutations are buffered — the clone is created
-            #      from the already-mutated reference, so it carries all the changes.
-            #   3. Call SetComponentProperty with the clone (a distinct object) so EDB registers
-            #      the update and persists it on save.
+            # fix (mirroring the dotnet pattern of GetComponentProperty().Clone())
             cmp_property = cmp.core.component_property
             if cmp_property is None:
                 self._logger.error(f"Component {cmp.name} has no component property.")

--- a/src/pyedb/grpc/database/components.py
+++ b/src/pyedb/grpc/database/components.py
@@ -36,11 +36,15 @@ from ansys.edb.core.definition.solder_ball_property import (
 )
 from ansys.edb.core.hierarchy.component_group import ComponentType as CoreComponentType
 
-# ansys-edb-core >= 0.4 introduced type-specific component property classes (ICComponentProperty,
-# IOComponentProperty, RLCComponentProperty) whose sub-property setters (die_property,
-# solder_ball_property, port_property) each issue their own direct RPC calls — no monolithic
-# SetComponentProperty write-back is required or accepted.  Older releases expose a flat
-# ComponentProperty object that must be written back via the component setter.
+# ansys-edb-core introduced type-specific component property classes (ICComponentProperty,
+# IOComponentProperty, RLCComponentProperty) when ICComponentProperty became importable.
+# These typed classes return **server-side copies** from their sub-property getters
+# (solder_ball_property, die_property, port_property).  Mutations on those copies are
+# persisted on the copy via direct RPC stubs, but the copy must be linked back to the
+# parent typed property via its setter (SetSolderBallProperty / SetDieProperty /
+# SetPortProperty) — no full SetComponentProperty write-back on the component is required.
+# Older releases expose a flat ComponentProperty whose mutations must be committed via a
+# full SetComponentProperty write-back on the component.
 try:
     from ansys.edb.core.definition.ic_component_property import (  # noqa: F401
         ICComponentProperty as _ICComponentProperty,
@@ -1338,9 +1342,19 @@ class Components(object):
             sball_shape = CoreSolderballShape.SOLDERBALL_SPHEROID
 
         if _EDB_CORE_TYPED_COMPONENT_PROPERTY:
-            # ansys-edb-core >= 0.4: typed component property — each sub-property setter
-            # issues its own direct RPC call; no SetComponentProperty write-back is needed
-            # (and would fail on the new server).
+            # ansys-edb-core typed component property (ICComponentProperty / IOComponentProperty).
+            #
+            # ansys-edb-core issue: ComponentGroup.component_property returns a *reference* to
+            # the live property object.  Calling SetComponentProperty with the same reference is
+            # treated as a no-op by the server and the changes are silently lost on save.  The
+            # fix (mirroring the dotnet pattern of GetComponentProperty().Clone()) is to:
+            #   1. Fetch the live reference and mutate its sub-properties via the typed setters
+            #      (SetDieProperty / SetSolderBallProperty / SetPortProperty) so those changes
+            #      are in the server-side buffer.
+            #   2. Clone the reference AFTER all mutations are buffered — the clone is created
+            #      from the already-mutated reference, so it carries all the changes.
+            #   3. Call SetComponentProperty with the clone (a distinct object) so EDB registers
+            #      the update and persists it on save.
             cmp_property = cmp.core.component_property
             if cmp_property is None:
                 self._logger.error(f"Component {cmp.name} has no component property.")
@@ -1358,6 +1372,7 @@ class Components(object):
                     ic_die_prop.die_orientation = CoreDieOrientation.CHIP_UP
                 else:
                     ic_die_prop.die_orientation = CoreDieOrientation.CHIP_DOWN
+                cmp_property.die_property = ic_die_prop
 
             solder_ball_prop = cmp_property.solder_ball_property
             solder_ball_prop.set_diameter(
@@ -1369,6 +1384,7 @@ class Components(object):
                 if not material_name in self._pedb.materials:
                     self._pedb.materials.add_conductor_material(name=material_name, conductivity=1e7)
                 solder_ball_prop.material_name = material_name
+            cmp_property.solder_ball_property = solder_ball_prop
 
             port_prop = cmp_property.port_property
             port_prop.reference_height = self._pedb._value_setter(reference_height)
@@ -1377,6 +1393,12 @@ class Components(object):
                 port_prop.set_reference_size(
                     self._pedb._value_setter(reference_size_x), self._pedb._value_setter(reference_size_y)
                 )
+            cmp_property.port_property = port_prop
+            # Clone the reference AFTER all sub-property mutations have been buffered so that the
+            # clone captures every change.  Pass the clone to SetComponentProperty — using a
+            # distinct (cloned) object is required for the server to register the update and
+            # persist it on save.
+            cmp.core.component_property = cmp_property.clone()
         else:
             # ansys-edb-core < 0.4: flat ComponentProperty — must write back via SetComponentProperty.
             cmp_property = cmp.component_property

--- a/src/pyedb/grpc/database/hierarchy/component.py
+++ b/src/pyedb/grpc/database/hierarchy/component.py
@@ -576,6 +576,8 @@ class Component(Group):
             cmp_property = self.core.component_property
             solder_ball_prop = cmp_property.solder_ball_property
             solder_ball_prop.height = Value(value)
+            cmp_property.solder_ball_property = solder_ball_prop
+            self.core.component_property = cmp_property.clone()
 
     @property
     def solder_ball_shape(self) -> str | None:
@@ -622,7 +624,7 @@ class Component(Group):
                 solder_ball_prop = cmp_property.solder_ball_property
                 solder_ball_prop.shape = shape
                 cmp_property.solder_ball_property = solder_ball_prop
-                self.core.component_property = cmp_property
+                self.core.component_property = cmp_property.clone()
 
     @property
     def solder_ball_diameter(self) -> Union[tuple[float, float], None]:
@@ -657,7 +659,7 @@ class Component(Group):
             solder_ball_prop = cmp_property.solder_ball_property
             solder_ball_prop.set_diameter(diameter, mid_diameter)
             cmp_property.solder_ball_property = solder_ball_prop
-            self.core.component_property = cmp_property
+            self.core.component_property = cmp_property.clone()
 
     @property
     def solder_ball_material(self) -> str:
@@ -1539,19 +1541,27 @@ class SolderBallProperty:
         return self._component.core.component_property.solder_ball_property
 
     def _write(self, mutate_fn):
-        """Helper: fetch raw core solder ball property → mutate → write back if needed.
+        """Helper: fetch raw core solder ball property → mutate → write back via clone.
 
-        With ansys-edb-core >= 0.4 (typed component property API) each SolderBallProperty
-        mutation method issues its own direct RPC call, so no write-back is required.
-        With older releases the entire component property must be written back.
+        ansys-edb-core issue: ``ComponentGroup.component_property`` returns a *reference* to the
+        live property object.  Calling ``SetComponentProperty`` with the same reference is a
+        server-side no-op and the change is silently lost on save.
+
+        Correct pattern (mirrors dotnet ``GetComponentProperty().Clone()``):
+        1. Fetch the live reference and update its ``solder_ball_property`` link via
+           ``SetSolderBallProperty`` so the change is queued in the server buffer.
+        2. Clone the reference *after* the mutation is buffered — the clone is made from the
+           already-mutated reference and therefore carries the change.
+        3. Call ``SetComponentProperty`` with the clone (a distinct object) so the server
+           registers the update and persists it on save.
         """
         cmp_property = self._component.core.component_property
         sbp = cmp_property.solder_ball_property
         mutate_fn(sbp)
-        if not _EDB_CORE_TYPED_COMPONENT_PROPERTY:
-            # Old API: mutations on sbp are local; write the whole property back.
-            cmp_property.solder_ball_property = sbp
-            self._component.core.component_property = cmp_property
+        # Step 1 – update the reference's solder-ball link.
+        cmp_property.solder_ball_property = sbp
+        # Steps 2 & 3 – clone then commit so the save picks up the change.
+        self._component.core.component_property = cmp_property.clone()
 
     @property
     def is_null(self) -> bool:
@@ -1672,7 +1682,7 @@ class ICDieProperty:
         else:
             return
         component_property.die_property = die_property
-        self._component.component_property = component_property
+        self._component.core.component_property = component_property.clone()
 
     @property
     def die_type(self) -> str:
@@ -1699,7 +1709,7 @@ class ICDieProperty:
         else:
             return
         component_property.die_property = die_property
-        self._component.component_property = component_property
+        self._component.core.component_property = component_property.clone()
 
     @property
     def height(self) -> float:
@@ -1719,7 +1729,7 @@ class ICDieProperty:
         die_property = component_property.die_property
         die_property.height = Value(value)
         component_property.die_property = die_property
-        self._component.component_property = component_property
+        self._component.core.component_property = component_property.clone()
 
     @property
     def is_null(self) -> bool:

--- a/tests/system/test_edb_components.py
+++ b/tests/system/test_edb_components.py
@@ -837,6 +837,44 @@ class TestClass(BaseTestClass):
         edb.close(terminate_rpc_session=False)
 
     @pytest.mark.skipif(not config["use_grpc"], reason="Not tested on DotNet.")
+    def test_grpc_set_solder_ball_ic_component_properties_persisted(self):
+        """set_solder_ball correctly persists all solder-ball and die properties for an IC component.
+
+        Regression test for the bug where ICComponentProperty sub-property getters return
+        server-side copies that were mutated but never linked back via the typed setter
+        (SetSolderBallProperty / SetDieProperty / SetPortProperty), so no changes were
+        reflected on the component.
+        """
+        edb = self.edb_examples.get_si_verse()
+        comp = edb.components["U1"]
+        assert comp.component_type == "ic", "U1 must be an IC component for this test to be meaningful"
+
+        sball_diam = 330e-6
+        sball_height = 330e-6
+        assert edb.components.set_solder_ball("U1", sball_diam=sball_diam, sball_height=sball_height)
+
+        # Height must be persisted
+        height = edb.components.get_solder_ball_height("U1")
+        assert isinstance(height, float)
+        assert height == pytest.approx(sball_height, rel=1e-3), f"Expected height {sball_height}, got {height}"
+
+        # Shape must be cylinder (default)
+        assert comp.solder_ball_shape == "cylinder"
+
+        # Diameter must be persisted
+        diam_result = comp.solder_ball_diameter
+        assert diam_result is not None, "solder_ball_diameter should not be None after set_solder_ball"
+        top_diam = float(diam_result[0])
+        assert top_diam == pytest.approx(sball_diam, rel=1e-3), f"Expected diameter {sball_diam}, got {top_diam}"
+
+        # IC die type must be set to flipchip
+        die_props = comp.ic_die_properties
+        assert die_props is not None, "ic_die_properties should be available for IC component"
+        assert die_props.die_type == "flipchip", f"Expected die_type 'flipchip', got '{die_props.die_type}'"
+
+        edb.close(terminate_rpc_session=False)
+
+    @pytest.mark.skipif(not config["use_grpc"], reason="Not tested on DotNet.")
     def test_grpc_get_aedt_pin_name(self):
         """get_aedt_pin_name returns a string AEDT pin name."""
         edb = self.edb_examples.get_si_verse()


### PR DESCRIPTION
This PR is providing workaround to assign solder ball on IC component due to issues on ansys-edb-core:
https://github.com/ansys/pyedb-core/issues/753
https://github.com/ansys/pyedb-core/issues/752

closes #2359