### PR TITLE
FIX: Chip orientation looking at all layers instead of only metal ones for auto die orientation evaluation

### DIFF
--- a/doc/changelog.d/2363.fixed.md
+++ b/doc/changelog.d/2363.fixed.md
@@ -1,0 +1,1 @@
+Chip orientation looking at all layers instead of only metal ones for auto die orientation evaluation

--- a/src/pyedb/grpc/database/components.py
+++ b/src/pyedb/grpc/database/components.py
@@ -1265,15 +1265,15 @@ class Components(object):
     def set_solder_ball(
         self,
         component: Union[str, Component] = "",
-        sball_diam: Optional[float] = None,
-        sball_height: Optional[float] = None,
+        sball_diam: Optional[float | int] = None,
+        sball_height: Optional[float | int] = None,
         shape: str = "Cylinder",
-        sball_mid_diam: Optional[float] = None,
-        chip_orientation: str = "chip_down",
+        sball_mid_diam: Optional[float | int] = None,
+        chip_orientation: Optional[str] = None,
         auto_reference_size: bool = True,
-        reference_size_x: float = 0,
-        reference_size_y: float = 0,
-        reference_height: float = 0,
+        reference_size_x: float | int = 0,
+        reference_size_y: float | int = 0,
+        reference_height: float | int = 0,
         material_name: str = None,
     ) -> bool:
         """Set solder ball properties for a component.
@@ -1290,8 +1290,11 @@ class Components(object):
             Solder ball shape ("Cylinder" or "Spheroid").
         sball_mid_diam : float, optional
             Solder ball mid diameter.
-        chip_orientation : str, optional
-            Chip orientation ("chip_down" or "chip_up").
+        chip_orientation : str or None, optional
+            Chip orientation (``"chip_down"`` or ``"chip_up"``). When ``None`` (default), the
+            orientation is auto-detected from the component placement layer: components placed on
+            the top signal layer receive ``"chip_down"``; those on any other signal layer receive
+            ``"chip_up"``. Pass an explicit value to override the auto-detection.
         auto_reference_size : bool, optional
             Use auto reference size.
         reference_size_x : float, optional
@@ -1357,11 +1360,14 @@ class Components(object):
             if cmp.core.component_type == CoreComponentType.IC:
                 ic_die_prop = cmp_property.die_property
                 ic_die_prop.die_type = CoreDieType.FLIPCHIP
-                # Top layer → chip_down (die faces down toward board), bottom layer → chip_up
-                if cmp.placement_layer == list(self._pedb.stackup.layers.keys())[0]:
-                    chip_orientation = "chip_down"
-                else:
-                    chip_orientation = "chip_up"
+                # Auto-detect orientation when caller did not provide one.
+                # Use signal_layers (not all layers) so that non-signal layers (e.g. dielectric)
+                # do not skew the top-layer comparison.
+                if chip_orientation is None:
+                    if cmp.placement_layer == list(self._pedb.stackup.signal_layers.keys())[0]:
+                        chip_orientation = "chip_down"
+                    else:
+                        chip_orientation = "chip_up"
                 if chip_orientation.lower() == "chip_up":
                     ic_die_prop.die_orientation = CoreDieOrientation.CHIP_UP
                 else:
@@ -1399,10 +1405,14 @@ class Components(object):
             if cmp.core.component_type == CoreComponentType.IC:
                 ic_die_prop = cmp_property.die_property
                 ic_die_prop.die_type = CoreDieType.FLIPCHIP
-                if cmp.placement_layer == list(self._pedb.stackup.layers.keys())[0]:
-                    chip_orientation = "chip_down"
-                else:
-                    chip_orientation = "chip_up"
+                # Auto-detect orientation when caller did not provide one.
+                # Use signal_layers (not all layers) so that non-signal layers (e.g. dielectric)
+                # do not skew the top-layer comparison.
+                if chip_orientation is None:
+                    if cmp.placement_layer == list(self._pedb.stackup.signal_layers.keys())[0]:
+                        chip_orientation = "chip_down"
+                    else:
+                        chip_orientation = "chip_up"
                 if chip_orientation.lower() == "chip_up":
                     ic_die_prop.die_orientation = CoreDieOrientation.CHIP_UP
                 else:

--- a/src/pyedb/grpc/database/components.py
+++ b/src/pyedb/grpc/database/components.py
@@ -1360,9 +1360,6 @@ class Components(object):
             if cmp.core.component_type == CoreComponentType.IC:
                 ic_die_prop = cmp_property.die_property
                 ic_die_prop.die_type = CoreDieType.FLIPCHIP
-                # Auto-detect orientation when caller did not provide one.
-                # Use signal_layers (not all layers) so that non-signal layers (e.g. dielectric)
-                # do not skew the top-layer comparison.
                 if chip_orientation is None:
                     if cmp.placement_layer == list(self._pedb.stackup.signal_layers.keys())[0]:
                         chip_orientation = "chip_down"
@@ -1394,10 +1391,6 @@ class Components(object):
                     self._pedb._value_setter(reference_size_x), self._pedb._value_setter(reference_size_y)
                 )
             cmp_property.port_property = port_prop
-            # Clone the reference AFTER all sub-property mutations have been buffered so that the
-            # clone captures every change.  Pass the clone to SetComponentProperty — using a
-            # distinct (cloned) object is required for the server to register the update and
-            # persist it on save.
             cmp.core.component_property = cmp_property.clone()
         else:
             # ansys-edb-core < 0.4: flat ComponentProperty — must write back via SetComponentProperty.
@@ -1405,9 +1398,6 @@ class Components(object):
             if cmp.core.component_type == CoreComponentType.IC:
                 ic_die_prop = cmp_property.die_property
                 ic_die_prop.die_type = CoreDieType.FLIPCHIP
-                # Auto-detect orientation when caller did not provide one.
-                # Use signal_layers (not all layers) so that non-signal layers (e.g. dielectric)
-                # do not skew the top-layer comparison.
                 if chip_orientation is None:
                     if cmp.placement_layer == list(self._pedb.stackup.signal_layers.keys())[0]:
                         chip_orientation = "chip_down"

--- a/tests/unit/test_components.py
+++ b/tests/unit/test_components.py
@@ -2793,7 +2793,7 @@ class TestSetSolderBall:
 
         comps = _make_components({"U1": cmp})
         comps._pedb._value_setter = lambda v: v
-        comps._pedb.stackup.layers = layers
+        comps._pedb.stackup.signal_layers = layers
         comps._pedb.materials = {}
 
         result = comps.set_solder_ball("U1", sball_diam=0.5e-3, sball_height=0.3e-3)
@@ -2911,7 +2911,7 @@ class TestSetSolderBallICChipUp:
 
         comps = _make_components({"U1": cmp})
         comps._pedb._value_setter = lambda v: v
-        comps._pedb.stackup.layers = layers
+        comps._pedb.stackup.signal_layers = layers
         comps._pedb.materials = MagicMock()
         comps._pedb.materials.__contains__ = MagicMock(return_value=True)
 
@@ -2946,6 +2946,122 @@ class TestSetSolderBallAutoRefSize:
             reference_size_y=1e-3,
         )
         assert result is True
+
+
+@_grpc_only
+class TestSetSolderBallChipOrientationFix:
+    """Tests for the two bugs fixed in set_solder_ball:
+
+    1. signal_layers (not layers) must be used to determine the top-layer boundary.
+    2. An explicit chip_orientation argument overrides the auto-detection logic.
+    """
+
+    def _make_ic_comps(self, placement_layer: str, signal_layer_order):
+        """Return a (comps, ic_die_prop) pair for an IC component.
+
+        The typed branch (``_EDB_CORE_TYPED_COMPONENT_PROPERTY=True``) reads
+        ``cmp.core.component_property`` and writes back through ``.clone()``.
+        We capture ``cmp.core.component_property.die_property`` so assertions
+        check the exact object that the production code mutates.
+        """
+        from ansys.edb.core.hierarchy.component_group import ComponentType as CoreComponentType
+
+        pin = MagicMock()
+        pin.padstack_def.data.layer_names = [signal_layer_order[0]]
+
+        cmp = _make_component("U1", "ic", num_pins=1)
+        cmp.pins = {"1": pin}
+        cmp.placement_layer = placement_layer
+        cmp.core.component_type = CoreComponentType.IC
+
+        core_comp_prop = cmp.core.component_property
+        ic_die_prop = core_comp_prop.die_property
+        # clone() must return the same property object so assertions hold
+        core_comp_prop.clone.return_value = core_comp_prop
+
+        signal_layers = MagicMock()
+        signal_layers.keys.return_value = iter(signal_layer_order)
+
+        comps = _make_components({"U1": cmp})
+        comps._pedb._value_setter = lambda v: v
+        comps._pedb.stackup.signal_layers = signal_layers
+        comps._pedb.materials = MagicMock()
+        comps._pedb.materials.__contains__ = MagicMock(return_value=True)
+        return comps, ic_die_prop
+
+    # Bug 1: signal_layers (not layers) must be used for auto-detection
+
+    def test_auto_detect_top_signal_layer_gives_chip_down(self):
+        """IC placed on the first signal layer must auto-detect chip_down."""
+        from ansys.edb.core.definition.die_property import DieOrientation as CoreDieOrientation
+
+        comps, ic_die_prop = self._make_ic_comps(placement_layer="TOP", signal_layer_order=["TOP", "BOT"])
+        result = comps.set_solder_ball("U1", sball_diam=0.5e-3, sball_height=0.3e-3)
+
+        assert result is True
+        assert ic_die_prop.die_orientation == CoreDieOrientation.CHIP_DOWN
+
+    def test_auto_detect_non_top_signal_layer_gives_chip_up(self):
+        """IC placed on a non-first signal layer must auto-detect chip_up."""
+        from ansys.edb.core.definition.die_property import DieOrientation as CoreDieOrientation
+
+        comps, ic_die_prop = self._make_ic_comps(placement_layer="BOT", signal_layer_order=["TOP", "BOT"])
+        result = comps.set_solder_ball("U1", sball_diam=0.5e-3, sball_height=0.3e-3)
+
+        assert result is True
+        assert ic_die_prop.die_orientation == CoreDieOrientation.CHIP_UP
+
+    def test_signal_layers_used_not_all_layers(self):
+        """Verify signal_layers dict is consulted, not the generic layers dict.
+
+        If the code still used stackup.layers the test would fail because only
+        stackup.signal_layers is configured with a meaningful key list.
+        """
+        from ansys.edb.core.definition.die_property import DieOrientation as CoreDieOrientation
+
+        comps, ic_die_prop = self._make_ic_comps(placement_layer="TOP", signal_layer_order=["TOP", "BOT"])
+        # Deliberately leave stackup.layers unconfigured (MagicMock with empty iter).
+        # If the production code used layers instead of signal_layers, list(...)[0]
+        # would raise IndexError and the test would fail.
+        result = comps.set_solder_ball("U1", sball_diam=0.5e-3, sball_height=0.3e-3)
+
+        assert result is True
+        assert ic_die_prop.die_orientation == CoreDieOrientation.CHIP_DOWN
+
+    # Bug 2: explicit chip_orientation argument must override auto-detection
+
+    def test_explicit_chip_up_overrides_top_layer_autodetect(self):
+        """chip_orientation='chip_up' must be respected even when the component
+        sits on the top signal layer (which would auto-detect as chip_down)."""
+        from ansys.edb.core.definition.die_property import DieOrientation as CoreDieOrientation
+
+        comps, ic_die_prop = self._make_ic_comps(placement_layer="TOP", signal_layer_order=["TOP", "BOT"])
+        result = comps.set_solder_ball("U1", sball_diam=0.5e-3, sball_height=0.3e-3, chip_orientation="chip_up")
+
+        assert result is True
+        assert ic_die_prop.die_orientation == CoreDieOrientation.CHIP_UP
+
+    def test_explicit_chip_down_overrides_bottom_layer_autodetect(self):
+        """chip_orientation='chip_down' must be respected even when the component
+        sits on a non-top signal layer (which would auto-detect as chip_up)."""
+        from ansys.edb.core.definition.die_property import DieOrientation as CoreDieOrientation
+
+        comps, ic_die_prop = self._make_ic_comps(placement_layer="BOT", signal_layer_order=["TOP", "BOT"])
+        result = comps.set_solder_ball("U1", sball_diam=0.5e-3, sball_height=0.3e-3, chip_orientation="chip_down")
+
+        assert result is True
+        assert ic_die_prop.die_orientation == CoreDieOrientation.CHIP_DOWN
+
+    def test_chip_orientation_none_triggers_autodetect(self):
+        """Passing chip_orientation=None explicitly should behave like the
+        default (auto-detect from placement layer)."""
+        from ansys.edb.core.definition.die_property import DieOrientation as CoreDieOrientation
+
+        comps, ic_die_prop = self._make_ic_comps(placement_layer="TOP", signal_layer_order=["TOP", "BOT"])
+        result = comps.set_solder_ball("U1", sball_diam=0.5e-3, sball_height=0.3e-3, chip_orientation=None)
+
+        assert result is True
+        assert ic_die_prop.die_orientation == CoreDieOrientation.CHIP_DOWN
 
 
 @_grpc_only


### PR DESCRIPTION
This is fixing issue #2362.

closes #2362