### PR TITLE
FIX: assign solder ball on IC component + adding simulation setup with configuration fix

### DIFF
--- a/doc/changelog.d/2397.fixed.md
+++ b/doc/changelog.d/2397.fixed.md
@@ -1,0 +1,1 @@
+Solder ball on IC fixed

--- a/doc/changelog.d/2397.fixed.md
+++ b/doc/changelog.d/2397.fixed.md
@@ -1,1 +1,1 @@
-Solder ball on IC fixed
+Assign solder ball on IC component + adding simulation setup with configuration fix

--- a/src/pyedb/configuration/cfg_components.py
+++ b/src/pyedb/configuration/cfg_components.py
@@ -398,6 +398,7 @@ class CfgComponent(CfgBase):
         height = sbp_data.get("height")
         mid_diameter = sbp_data.get("mid_diameter", diameter)
         material = sbp_data.get("material") or "solder"
+        orientation = sbp_data.get("orientation", "chip_down")
 
         _shape_map = {
             "cylinder": SolderballShape.SOLDERBALL_CYLINDER,
@@ -406,7 +407,21 @@ class CfgComponent(CfgBase):
         core_shape = _shape_map[shape.lower()]  # raises KeyError for unknown shapes
 
         if self._pedb.grpc:
-            cp = self.pyedb_obj.component_property
+            cp = self.pyedb_obj.core.component_property
+            # For IC components whose die type is NONE, default it to FLIPCHIP so
+            # that HFSS recognises the solder balls during simulation.
+            # This is the only way to get solder balls defined with release 2026.1.
+            # the die property MUST be a brand-new CoreDieProperty.create() object
+            # mutating the fetched instance and re-assigning it does NOT persist.
+            comp_type = getattr(self.pyedb_obj, "type", "") or ""
+            if comp_type.lower() == "ic":
+                if cp.die_property.die_type in (None, CoreDieType.NONE):
+                    new_die_prop = CoreDieProperty.create()
+                    new_die_prop.die_type = CoreDieType.FLIPCHIP
+                    new_die_prop.die_orientation = (
+                        CoreDieOrientation.CHIP_UP if orientation.lower() == "chip_up" else CoreDieOrientation.CHIP_DOWN
+                    )
+                    cp.die_property = new_die_prop
             sbp = CoreSolderBallProperty.create()
             sbp.shape = core_shape
             sbp.set_diameter(self._pedb.value(diameter), self._pedb.value(mid_diameter))
@@ -421,7 +436,7 @@ class CfgComponent(CfgBase):
                 sball_height=self._pedb.edb_value(height).ToDouble() if height else None,
                 shape=shape.capitalize(),
                 sball_mid_diam=self._pedb.edb_value(mid_diameter).ToDouble() if mid_diameter else None,
-                chip_orientation=sbp_data.get("orientation", "chip_down"),
+                chip_orientation=orientation,
                 material_name=material,
             )
 
@@ -439,6 +454,11 @@ class CfgComponent(CfgBase):
     def _retrieve_solder_ball_properties_from_edb(self):
         cp = self.pyedb_obj
         diam = cp.solder_ball_diameter
+        if diam is None:
+            # Component has no solder ball configured yet — leave empty so that
+            # set_solder_ball_properties() can populate it from scratch.
+            self.solder_ball_properties = {}
+            return
         self.solder_ball_properties = {
             "uses_solder_ball": cp.uses_solderball,
             "shape": cp.solder_ball_shape,
@@ -452,11 +472,12 @@ class CfgComponent(CfgBase):
         if self.type.lower() not in ("ic", "io", "other"):
             return
         pp = self.pyedb_obj.component_property.port_property
+        ref_size = pp.get_reference_size() if callable(getattr(pp, "get_reference_size", None)) else None
         self.port_properties = {
             "reference_height": str(pp.reference_height),
             "reference_size_auto": pp.reference_size_auto,
-            "reference_size_x": str(pp.get_reference_size()[0]),
-            "reference_size_y": str(pp.get_reference_size()[1]),
+            "reference_size_x": str(ref_size[0]) if ref_size is not None else "0",
+            "reference_size_y": str(ref_size[1]) if ref_size is not None else "0",
         }
 
     def set_parameters_to_edb(self):

--- a/src/pyedb/configuration/cfg_components.py
+++ b/src/pyedb/configuration/cfg_components.py
@@ -420,10 +420,9 @@ class CfgComponent(CfgBase):
             cp = self.pyedb_obj.core.component_property
 
             # For IC components, solder balls imply a flip-chip die.  If the
-            # user did not explicitly configure a non-trivial die type (i.e. the
-            # effective die type is still "no_die"), override it with FLIPCHIP
+            # user did not explicitly configure die type override it with FLIPCHIP
             # and use the orientation stored in the solder-ball data.  This
-            # mirrors the behaviour of ``components.set_solder_ball`` which
+            # mirrors the behavior of ``components.set_solder_ball`` which
             # always sets die_type = FLIPCHIP when processing an IC.
             if self.pyedb_obj.type.lower() == "ic":
                 configured_die_type = (self.ic_die_properties.get("type") or "no_die").lower()

--- a/src/pyedb/configuration/cfg_components.py
+++ b/src/pyedb/configuration/cfg_components.py
@@ -31,6 +31,7 @@ from ansys.edb.core.definition.die_property import (
     DieType as CoreDieType,
 )
 from ansys.edb.core.definition.port_property import PortProperty as CorePortProperty
+from ansys.edb.core.definition.solder_ball_property import SolderBallProperty as CoreSolderBallProperty, SolderballShape
 from pydantic import BaseModel
 
 from pyedb.configuration.cfg_common import CfgBase
@@ -392,25 +393,27 @@ class CfgComponent(CfgBase):
             return
         shape = sbp_data.get("shape")
         if not shape:
-            return
+            raise ValueError("Solderball shape must be either cylinder or spheroid")
         diameter = sbp_data.get("diameter")
         height = sbp_data.get("height")
         mid_diameter = sbp_data.get("mid_diameter", diameter)
-        material = sbp_data.get("material")
+        material = sbp_data.get("material") or "solder"
 
-        # Delegate entirely to components.set_solder_ball(), which already
-        # handles IC die-type (FLIPCHIP) and orientation internally — no need
-        # to duplicate that logic here.
+        _shape_map = {
+            "cylinder": SolderballShape.SOLDERBALL_CYLINDER,
+            "spheroid": SolderballShape.SOLDERBALL_SPHEROID,
+        }
+        core_shape = _shape_map[shape.lower()]  # raises KeyError for unknown shapes
+
         if self._pedb.grpc:
-            self._pedb.components.set_solder_ball(
-                component=self.pyedb_obj.name,
-                sball_diam=diameter,
-                sball_height=height,
-                shape=shape.capitalize(),
-                sball_mid_diam=mid_diameter,
-                chip_orientation=sbp_data.get("orientation", "chip_down"),
-                material_name=material or "solder",
-            )
+            cp = self.pyedb_obj.component_property
+            sbp = CoreSolderBallProperty.create()
+            sbp.shape = core_shape
+            sbp.set_diameter(self._pedb.value(diameter), self._pedb.value(mid_diameter))
+            sbp.height = self._pedb.value(height)
+            sbp.material_name = material
+            cp.solder_ball_property = sbp
+            _persist_component_property(self.pyedb_obj.core, cp)
         else:
             self._pedb.components.set_solder_ball(
                 component=self.pyedb_obj.name,
@@ -419,7 +422,7 @@ class CfgComponent(CfgBase):
                 shape=shape.capitalize(),
                 sball_mid_diam=self._pedb.edb_value(mid_diameter).ToDouble() if mid_diameter else None,
                 chip_orientation=sbp_data.get("orientation", "chip_down"),
-                material_name=material or "solder",
+                material_name=material,
             )
 
     def _retrieve_ic_die_properties_from_edb(self):

--- a/src/pyedb/configuration/cfg_components.py
+++ b/src/pyedb/configuration/cfg_components.py
@@ -418,6 +418,24 @@ class CfgComponent(CfgBase):
             # ``cp.solder_ball_property`` does not persist on EDB 2026.1, even
             # with the base-class write-back).
             cp = self.pyedb_obj.core.component_property
+
+            # For IC components, solder balls imply a flip-chip die.  If the
+            # user did not explicitly configure a non-trivial die type (i.e. the
+            # effective die type is still "no_die"), override it with FLIPCHIP
+            # and use the orientation stored in the solder-ball data.  This
+            # mirrors the behaviour of ``components.set_solder_ball`` which
+            # always sets die_type = FLIPCHIP when processing an IC.
+            if self.pyedb_obj.type.lower() == "ic":
+                configured_die_type = (self.ic_die_properties.get("type") or "no_die").lower()
+                if configured_die_type in _NO_DIE_TYPES:
+                    ic_die_prop = CoreDieProperty.create()
+                    ic_die_prop.die_type = CoreDieType.FLIPCHIP
+                    orientation = (sbp_data.get("orientation") or "chip_down").lower()
+                    ic_die_prop.die_orientation = (
+                        CoreDieOrientation.CHIP_UP if orientation == "chip_up" else CoreDieOrientation.CHIP_DOWN
+                    )
+                    cp.die_property = ic_die_prop
+
             sbp = CoreSolderBallProperty.create()
             if shape_lower == "cylinder":
                 sbp.set_diameter(self._pedb.value(diameter), self._pedb.value(diameter))

--- a/src/pyedb/configuration/cfg_components.py
+++ b/src/pyedb/configuration/cfg_components.py
@@ -31,14 +31,9 @@ from ansys.edb.core.definition.die_property import (
     DieType as CoreDieType,
 )
 from ansys.edb.core.definition.port_property import PortProperty as CorePortProperty
-from ansys.edb.core.definition.solder_ball_property import (
-    SolderBallProperty as CoreSolderBallProperty,
-    SolderballShape as CoreSolderballShape,
-)
 from pydantic import BaseModel
 
 from pyedb.configuration.cfg_common import CfgBase
-from pyedb.grpc.database.components import _EDB_CORE_TYPED_COMPONENT_PROPERTY
 
 
 def _smallest_pin_pad_size(comp) -> float | None:
@@ -84,12 +79,6 @@ def _get_snake_to_pascal():
 
     return snake_to_pascal
 
-
-_solder_shape_mapping = {
-    "cylinder": CoreSolderballShape.SOLDERBALL_CYLINDER,
-    "spheroid": CoreSolderballShape.SOLDERBALL_SPHEROID,
-    "no_solder_ball": CoreSolderballShape.NO_SOLDERBALL,
-}
 
 _die_type_mapping = {
     "flip_chip": CoreDieType.FLIPCHIP,
@@ -402,54 +391,27 @@ class CfgComponent(CfgBase):
         if not sbp_data:
             return
         shape = sbp_data.get("shape")
+        if not shape:
+            return
         diameter = sbp_data.get("diameter")
         height = sbp_data.get("height")
         mid_diameter = sbp_data.get("mid_diameter", diameter)
         material = sbp_data.get("material")
 
+        # Delegate entirely to components.set_solder_ball(), which already
+        # handles IC die-type (FLIPCHIP) and orientation internally — no need
+        # to duplicate that logic here.
         if self._pedb.grpc:
-            if not shape:
-                raise ValueError("Solderball shape must be either cylinder or spheroid")
-            shape_lower = shape.lower()
-            if shape_lower not in ("cylinder", "spheroid"):
-                raise ValueError("Solderball shape must be either cylinder or spheroid")
-            # See ``_persist_component_property``: we MUST instantiate a brand-
-            # new SolderBallProperty (mutating one returned from
-            # ``cp.solder_ball_property`` does not persist on EDB 2026.1, even
-            # with the base-class write-back).
-            cp = self.pyedb_obj.core.component_property
-
-            # For IC components, solder balls imply a flip-chip die.  If the
-            # user did not explicitly configure die type override it with FLIPCHIP
-            # and use the orientation stored in the solder-ball data.  This
-            # mirrors the behavior of ``components.set_solder_ball`` which
-            # always sets die_type = FLIPCHIP when processing an IC.
-            if self.pyedb_obj.type.lower() == "ic":
-                configured_die_type = (self.ic_die_properties.get("type") or "no_die").lower()
-                if configured_die_type in _NO_DIE_TYPES:
-                    ic_die_prop = CoreDieProperty.create()
-                    ic_die_prop.die_type = CoreDieType.FLIPCHIP
-                    orientation = (sbp_data.get("orientation") or "chip_down").lower()
-                    ic_die_prop.die_orientation = (
-                        CoreDieOrientation.CHIP_UP if orientation == "chip_up" else CoreDieOrientation.CHIP_DOWN
-                    )
-                    cp.die_property = ic_die_prop
-
-            sbp = CoreSolderBallProperty.create()
-            if shape_lower == "cylinder":
-                sbp.set_diameter(self._pedb.value(diameter), self._pedb.value(diameter))
-            else:  # spheroid
-                sbp.set_diameter(self._pedb.value(diameter), self._pedb.value(mid_diameter))
-            sbp.shape = _solder_shape_mapping[shape_lower]
-            if height is not None:
-                sbp.height = self._pedb.value(height)
-            if material is not None:
-                sbp.material_name = material
-            cp.solder_ball_property = sbp
-            _persist_component_property(self.pyedb_obj.core, cp)
+            self._pedb.components.set_solder_ball(
+                component=self.pyedb_obj.name,
+                sball_diam=diameter,
+                sball_height=height,
+                shape=shape.capitalize(),
+                sball_mid_diam=mid_diameter,
+                chip_orientation=sbp_data.get("orientation", "chip_down"),
+                material_name=material or "solder",
+            )
         else:
-            if not shape:
-                return
             self._pedb.components.set_solder_ball(
                 component=self.pyedb_obj.name,
                 sball_diam=self._pedb.edb_value(diameter).ToDouble() if diameter else None,

--- a/src/pyedb/configuration/configuration.py
+++ b/src/pyedb/configuration/configuration.py
@@ -295,15 +295,8 @@ class Configuration:
         self.apply_terminals()
         self._pedb.layout.use_cache = False
         self.__apply_with_logging("Placing probes", self.cfg_data.probes.apply)
-        # Setups are applied BEFORE operations (cutout) because the cutout
-        # implementation saves the design to disk mid-run (save_as(legacy_path))
-        # to persist the clipped geometry.  If setups were applied after that
-        # save, the EDB file on disk would not contain them — only the
-        # subsequent edb.close() (without an explicit save) would discard them.
         # Applying setups first ensures they are present in the in-memory design
-        # when the cutout triggers its internal save.  The in-place multithread
-        # cutout only removes nets / primitives / padstack instances and never
-        # touches simulation setups, so setups created here are preserved.
+        # when the cutout triggers its internal save.
         self.apply_setups()
         self.apply_operations()
 

--- a/src/pyedb/configuration/configuration.py
+++ b/src/pyedb/configuration/configuration.py
@@ -295,8 +295,17 @@ class Configuration:
         self.apply_terminals()
         self._pedb.layout.use_cache = False
         self.__apply_with_logging("Placing probes", self.cfg_data.probes.apply)
-        self.apply_operations()
+        # Setups are applied BEFORE operations (cutout) because the cutout
+        # implementation saves the design to disk mid-run (save_as(legacy_path))
+        # to persist the clipped geometry.  If setups were applied after that
+        # save, the EDB file on disk would not contain them — only the
+        # subsequent edb.close() (without an explicit save) would discard them.
+        # Applying setups first ensures they are present in the in-memory design
+        # when the cutout triggers its internal save.  The in-place multithread
+        # cutout only removes nets / primitives / padstack instances and never
+        # touches simulation setups, so setups created here are preserved.
         self.apply_setups()
+        self.apply_operations()
 
         return True
 
@@ -328,10 +337,10 @@ class Configuration:
             else:
                 if setup.type == "hfss":
                     edb_setup = self._pedb.simulation_setups.create(name=setup.name, solver="hfss")
-                    edb_setup.adaptive_settings.adapt_type = FAdaptTypeMapper.get(
-                        setup.adapt_type, as_grpc=settings.is_grpc
-                    )
                     if not settings.is_grpc:
+                        edb_setup.adaptive_settings.adapt_type = FAdaptTypeMapper.get(
+                            setup.adapt_type, as_grpc=settings.is_grpc
+                        )
                         edb_setup.adaptive_settings.clean_adaptive_frequency_data_list()
                         if setup.adapt_type == "single":
                             edb_setup.adaptive_settings.add_adaptive_frequency_data(
@@ -354,19 +363,25 @@ class Configuration:
                             raise ValueError(f"Adapt type {setup.adapt_type} is not supported.")
 
                     else:
+                        # gRPC path: use the dedicated set_solution_* methods which access the raw
+                        # proto directly and persist correctly.  Avoid the deprecated
+                        # ``adaptive_settings`` property and the wrapper write-back bug where
+                        # passing a SingleFrequencyAdaptiveSolution / BroadbandAdaptiveSolution
+                        # wrapper (instead of its ``.core`` proto) to the proto field setter would
+                        # raise a TypeError and abort before the frequency sweeps are added.
                         if setup.adapt_type == "single":
-                            s_f_adapt = edb_setup.settings.general.single_frequency_adaptive_solution
-                            s_f_adapt.adaptive_frequency = setup.single_frequency_adaptive_solution.adaptive_frequency
-                            s_f_adapt.max_passes = setup.single_frequency_adaptive_solution.max_passes
-                            s_f_adapt.max_delta = setup.single_frequency_adaptive_solution.max_delta
-                            edb_setup.core.settings.general.single_frequency_adaptive_solution = s_f_adapt
+                            edb_setup.set_solution_single_frequency(
+                                frequency=setup.single_frequency_adaptive_solution.adaptive_frequency,
+                                max_num_passes=setup.single_frequency_adaptive_solution.max_passes,
+                                max_delta_s=setup.single_frequency_adaptive_solution.max_delta,
+                            )
                         elif setup.adapt_type == "broadband":
-                            b_f_adapt = edb_setup.settings.general.broadband_adaptive_solution
-                            b_f_adapt.low_frequency = setup.broadband_adaptive_solution.low_frequency
-                            b_f_adapt.high_frequency = setup.broadband_adaptive_solution.high_frequency
-                            b_f_adapt.max_delta = setup.broadband_adaptive_solution.max_delta
-                            b_f_adapt.max_passes = setup.broadband_adaptive_solution.max_passes
-                            edb_setup.core.settings.general.broadband_adaptive_solution = b_f_adapt
+                            edb_setup.set_solution_broadband(
+                                low_frequency=setup.broadband_adaptive_solution.low_frequency,
+                                high_frequency=setup.broadband_adaptive_solution.high_frequency,
+                                max_delta_s=setup.broadband_adaptive_solution.max_delta,
+                                max_num_passes=setup.broadband_adaptive_solution.max_passes,
+                            )
                         else:
                             raise ValueError(f"Adapt type {setup.adapt_type} is not supported.")
 

--- a/src/pyedb/configuration/configuration.py
+++ b/src/pyedb/configuration/configuration.py
@@ -356,12 +356,7 @@ class Configuration:
                             raise ValueError(f"Adapt type {setup.adapt_type} is not supported.")
 
                     else:
-                        # gRPC path: use the dedicated set_solution_* methods which access the raw
-                        # proto directly and persist correctly.  Avoid the deprecated
-                        # ``adaptive_settings`` property and the wrapper write-back bug where
-                        # passing a SingleFrequencyAdaptiveSolution / BroadbandAdaptiveSolution
-                        # wrapper (instead of its ``.core`` proto) to the proto field setter would
-                        # raise a TypeError and abort before the frequency sweeps are added.
+                        # use the dedicated set_solution_* methods
                         if setup.adapt_type == "single":
                             edb_setup.set_solution_single_frequency(
                                 frequency=setup.single_frequency_adaptive_solution.adaptive_frequency,

--- a/src/pyedb/grpc/database/simulation_setup/hfss_simulation_setup.py
+++ b/src/pyedb/grpc/database/simulation_setup/hfss_simulation_setup.py
@@ -27,9 +27,6 @@ if TYPE_CHECKING:
 from typing import Union
 
 from ansys.edb.core.simulation_setup.adaptive_solutions import AdaptiveFrequency as CoreAdaptiveFrequency
-from ansys.edb.core.simulation_setup.hfss_simulation_settings import (
-    AdaptType as CoreAdaptType,
-)
 from ansys.edb.core.simulation_setup.hfss_simulation_setup import (
     HfssSimulationSetup as CoreHfssSimulationSetup,
 )
@@ -226,12 +223,12 @@ class HfssSimulationSetup(SimulationSetup):
         bool.
 
         """
-        self.core.settings.general.adaptive_solution_type = CoreAdaptType.SINGLE
-        sfs = self.core.settings.general.single_frequency_adaptive_solution
+        general = self.settings.general
+        general.adaptive_solution_type = "single"
+        sfs = general.single_frequency_adaptive_solution
         sfs.adaptive_frequency = frequency
         sfs.max_passes = max_num_passes
         sfs.max_delta = str(max_delta_s)
-        self.core.settings.general.single_frequency_adaptive_solution = sfs
         return True
 
     def set_solution_multi_frequencies(self, frequencies="5GHz", max_delta_s=0.02, max_passes=10) -> bool:
@@ -251,7 +248,8 @@ class HfssSimulationSetup(SimulationSetup):
         bool.
 
         """
-        self.settings.general.adaptive_solution_type = "multi_frequencies"
+        general = self.settings.general
+        general.adaptive_solution_type = "multi_frequencies"
         if not isinstance(frequencies, list | tuple):
             frequencies = [frequencies]
         if not isinstance(max_delta_s, list | tuple):
@@ -262,10 +260,9 @@ class HfssSimulationSetup(SimulationSetup):
         adapt_frequencies = [
             CoreAdaptiveFrequency(frequencies[ind], str(max_delta_s[ind])) for ind in range(len(frequencies))
         ]
-        mfs = self.core.settings.general.multi_frequency_adaptive_solution
+        mfs = general.multi_frequency_adaptive_solution
         mfs.adaptive_frequencies = adapt_frequencies
         mfs.max_passes = max_passes
-        self.core.settings.general.multi_frequency_adaptive_solution = mfs
         return True
 
     def set_solution_broadband(self, low_frequency="1GHz", high_frequency="10GHz", max_delta_s=0.02, max_num_passes=10):
@@ -287,16 +284,13 @@ class HfssSimulationSetup(SimulationSetup):
         bool.
 
         """
-        # Access the raw proto directly (same pattern as set_solution_single_frequency) so that the
-        # final write-back uses the proto object, not a Python wrapper.  Passing a
-        # BroadbandAdaptiveSolution wrapper to a proto field setter raises a TypeError.
-        self.core.settings.general.adaptive_solution_type = CoreAdaptType.BROADBAND
-        bfs = self.core.settings.general.broadband_adaptive_solution
-        bfs.low_frequency = str(low_frequency)
-        bfs.high_frequency = str(high_frequency)
-        bfs.max_delta = str(max_delta_s)
-        bfs.max_num_passes = int(max_num_passes)
-        self.core.settings.general.broadband_adaptive_solution = bfs
+        general = self.settings.general
+        general.adaptive_solution_type = "broadband"
+        bbs = general.broadband_adaptive_solution
+        bbs.low_frequency = str(low_frequency)
+        bbs.high_frequency = str(high_frequency)
+        bbs.max_delta = str(max_delta_s)
+        bbs.max_num_passes = int(max_num_passes)
         return True
 
     def add_adaptive_frequency_data(self, frequency="5GHz", max_delta_s="0.01"):

--- a/src/pyedb/grpc/database/simulation_setup/hfss_simulation_setup.py
+++ b/src/pyedb/grpc/database/simulation_setup/hfss_simulation_setup.py
@@ -287,12 +287,15 @@ class HfssSimulationSetup(SimulationSetup):
         bool.
 
         """
-        self.settings.general.adaptive_solution_type = "broadband"
-        bfs = self.settings.general.broadband_adaptive_solution
-        bfs.low_frequency = low_frequency
-        bfs.high_frequency = high_frequency
-        bfs.max_delta = max_delta_s
-        bfs.max_num_passes = max_num_passes
+        # Access the raw proto directly (same pattern as set_solution_single_frequency) so that the
+        # final write-back uses the proto object, not a Python wrapper.  Passing a
+        # BroadbandAdaptiveSolution wrapper to a proto field setter raises a TypeError.
+        self.core.settings.general.adaptive_solution_type = CoreAdaptType.BROADBAND
+        bfs = self.core.settings.general.broadband_adaptive_solution
+        bfs.low_frequency = str(low_frequency)
+        bfs.high_frequency = str(high_frequency)
+        bfs.max_delta = str(max_delta_s)
+        bfs.max_num_passes = int(max_num_passes)
         self.core.settings.general.broadband_adaptive_solution = bfs
         return True
 

--- a/src/pyedb/workflows/utilities/cutout.py
+++ b/src/pyedb/workflows/utilities/cutout.py
@@ -775,7 +775,7 @@ class GrpcCutout:
 
         # components
         _t1 = time.time()
-        components_to_delete = [comp for comp in all_components if comp.numpins == 0]
+        components_to_delete = [comp for comp in all_components if comp.num_pins == 0]
         for comp in components_to_delete:
             comp.delete()
         if self.remove_single_pin_components:

--- a/tests/unit/test_components.py
+++ b/tests/unit/test_components.py
@@ -411,6 +411,97 @@ class TestCfgComponentSolderBallGrpc:
         # (recorded as ``_persisted_component_property`` by the fixture stub).
         assert hasattr(obj.core, "_persisted_component_property")
 
+    def test_ic_die_type_none_defaults_to_flipchip(self, _mock_core_property_factories):
+        """When an IC component's die_type is NONE, _set_solder_ball_properties_to_edb
+        must default it to FLIPCHIP so HFSS recognises the solder balls."""
+        from ansys.edb.core.definition.die_property import DieType as CoreDieType
+
+        pedb = _make_pedb(grpc=True)
+        obj = _make_pyedb_obj("ic")
+        # Simulate die_type = NONE (uninitialized IC)
+        obj.core.component_property.die_property.die_type = CoreDieType.NONE
+
+        c = CfgComponent(
+            pedb,
+            obj,
+            reference_designator="U1",
+            part_type="ic",
+            solder_ball_properties={"shape": "cylinder", "diameter": "150um", "height": "100um"},
+        )
+        c._set_solder_ball_properties_to_edb()
+
+        # die_type must have been updated to FLIPCHIP on the die_property object
+        ic_die_prop = obj.core.component_property.die_property
+        assert ic_die_prop.die_type == CoreDieType.FLIPCHIP
+        # Solder ball property must still be created and persisted
+        assert _mock_core_property_factories.last_sbp is not None
+        assert hasattr(obj.core, "_persisted_component_property")
+
+    def test_ic_die_type_already_set_is_not_overridden(self, _mock_core_property_factories):
+        """When die_type is already WIREBOND (or FLIPCHIP), it must not be changed."""
+        from ansys.edb.core.definition.die_property import DieType as CoreDieType
+
+        pedb = _make_pedb(grpc=True)
+        obj = _make_pyedb_obj("ic")
+        obj.core.component_property.die_property.die_type = CoreDieType.WIREBOND
+
+        c = CfgComponent(
+            pedb,
+            obj,
+            reference_designator="U1",
+            part_type="ic",
+            solder_ball_properties={"shape": "cylinder", "diameter": "150um", "height": "100um"},
+        )
+        c._set_solder_ball_properties_to_edb()
+
+        # die_type must remain WIREBOND — only NONE triggers the default
+        assert obj.core.component_property.die_property.die_type == CoreDieType.WIREBOND
+
+
+class TestRetrieveSolderBallProperties:
+    """Regression: _retrieve_solder_ball_properties_from_edb must not crash
+    when the component has no solder ball configured (solder_ball_diameter == None).
+    This was the root cause of cfg.components.get("U1") silently losing U1.
+    """
+
+    def test_no_solder_ball_yields_empty_dict(self):
+        """solder_ball_diameter returning None → solder_ball_properties = {}."""
+        pedb = _make_pedb(grpc=True)
+        obj = _make_pyedb_obj("ic")
+        obj.solder_ball_diameter = None  # simulate unconfigured component
+        c = CfgComponent(pedb, obj, reference_designator="U1", part_type="ic")
+        c._retrieve_solder_ball_properties_from_edb()
+        assert c.solder_ball_properties == {}
+
+    def test_no_solder_ball_then_set_overrides(self):
+        """After retrieve returns {}, set_solder_ball_properties populates correctly."""
+        pedb = _make_pedb(grpc=True)
+        obj = _make_pyedb_obj("ic")
+        obj.solder_ball_diameter = None
+        c = CfgComponent(pedb, obj, reference_designator="U1", part_type="ic")
+        c._retrieve_solder_ball_properties_from_edb()
+        c.set_solder_ball_properties(shape="cylinder", diameter="300um", height="200um")
+        assert c.solder_ball_properties["shape"] == "cylinder"
+        assert c.solder_ball_properties["diameter"] == "300um"
+
+    def test_configured_solder_ball_is_read(self):
+        """When solder_ball_diameter is present, properties are read normally."""
+        from unittest.mock import MagicMock
+
+        pedb = _make_pedb(grpc=True)
+        obj = _make_pyedb_obj("ic")
+        d0, d1 = MagicMock(), MagicMock()
+        d0.__str__ = lambda self: "150um"
+        d1.__str__ = lambda self: "150um"
+        obj.solder_ball_diameter = (d0, d1)
+        obj.uses_solderball = True
+        obj.solder_ball_shape = "cylinder"
+        obj.solder_ball_height = MagicMock(__str__=lambda self: "100um")
+        obj.solder_ball_material = "solder"
+        c = CfgComponent(pedb, obj, reference_designator="U1", part_type="ic")
+        c._retrieve_solder_ball_properties_from_edb()
+        assert c.solder_ball_properties.get("shape") == "cylinder"
+
 
 class TestCfgComponentPortPropertiesGrpcRegression:
     """Lightweight regression check that the write-back helper is invoked.


### PR DESCRIPTION
This PR is fixing 2 issues #2399 and #2400.
- Solder balls were not created on IC component due to IC properties not being applied by default
- Simulation setup was removed due to bad sequence of operation during configuration application. Cutout was removing simulation setup.

closes #2399 
closes #2400 
