### PR TITLE
FEAT: create port on component with coax port does not require reference net

### DIFF
--- a/doc/changelog.d/2426.added.md
+++ b/doc/changelog.d/2426.added.md
@@ -1,0 +1,1 @@
+Create port on component with coax port does not require reference net

--- a/src/pyedb/grpc/database/source_excitations.py
+++ b/src/pyedb/grpc/database/source_excitations.py
@@ -768,8 +768,12 @@ class SourceExcitation(SourceExcitationInternal):
         do_pingroup : bool
             True activate pingroup during port creation (only used with combination of CircPort),
             False will take the closest reference pin and generate one port per signal pin.
-        reference_net : string or list of string.
-            list of the reference net.
+        reference_net : string or list of string, optional
+            List of reference nets. For ``coax_port`` this argument is not used to build the port
+            (coax ports are self-contained solder-ball ports) so it can be ``None`` or empty.
+            If supplied, any net that appears in both ``net_list`` and ``reference_net`` is removed
+            from ``net_list`` before port creation. For ``circuit_port`` a reference net is required
+            to pair each signal terminal with a reference terminal.
         port_name : str
             Port name for overwriting the default port-naming convention,
             which is ``[component][net][pin]``. The port name must be unique.
@@ -814,6 +818,8 @@ class SourceExcitation(SourceExcitationInternal):
             component = self._pedb.components.instances[component]
         if not isinstance(net_list, list):
             net_list = [net_list]
+        # Defensive copy so the caller's list is never mutated.
+        net_list = list(net_list)
         for net in net_list:
             if not isinstance(net, str):
                 try:
@@ -825,6 +831,8 @@ class SourceExcitation(SourceExcitationInternal):
                         f"A(n) {type(e).__name__} error occurred while attempting to append 'name' "
                         f"of net {net} to list of nets {net_list}: {str(e)}"
                     )
+        if reference_net is None:
+            reference_net = []
         if isinstance(reference_net, str) or isinstance(reference_net, Net):
             reference_net = [reference_net]
         _reference_net = [ref.name if isinstance(ref, Net) else ref for ref in reference_net]
@@ -848,13 +856,14 @@ class SourceExcitation(SourceExcitationInternal):
             if not solder_balls_mid_size:
                 solder_balls_mid_size = self._pedb.components.instances[component.name].solder_ball_diameter[1]
             ref_pins = [p for p in list(component.pins.values()) if p.net_name in reference_net]
-            if not ref_pins:
-                self._logger.error(
-                    "No reference pins found on component. You might consider"
-                    "using Circuit port instead since reference pins can be extended"
-                    "outside the component when not found if argument extend_reference_pins_outside_component is True."
+            if not ref_pins and reference_net:
+                self._logger.warning(
+                    "No reference pins found on component for coax port. "
+                    "Coax ports do not require a reference net — proceeding without reference pins. "
+                    "If a circuit port with a reference terminal is needed, use port_type='circuit_port'. "
+                    "Reference pins can also be extended outside the component by setting "
+                    "extend_reference_pins_outside_component=True."
                 )
-                return False
             pad_params = self._pedb.padstacks.get_pad_parameters(pin=cmp_pins[0], layername=pin_layers[0], pad_type=0)
             if not pad_params[0] == 7:
                 if not solder_balls_size:  # pragma no cover

--- a/tests/unit/test_ports.py
+++ b/tests/unit/test_ports.py
@@ -401,6 +401,99 @@ class TestCreatePortOnComponentValidation:
         assert result is False
 
 
+class TestCreatePortOnComponentReferenceNetFixes:
+    """Tests for the reference_net / net_list mutation fixes (issue: coax hard-fail on missing ref pins)."""
+
+    pytestmark = [pytest.mark.grpc]
+
+    def _make_signal_pin(self, net_name):
+        pin = MagicMock()
+        pin.net_name = net_name
+        pin.is_layout_pin = False
+        pad_def = MagicMock()
+        pad_def.data.layer_names = ["TOP", "BOTTOM"]
+        pin.padstack_def = pad_def
+        return pin
+
+    def test_reference_net_none_does_not_crash(self):
+        """reference_net=None must not raise; if no signal pins are found it returns False."""
+        exc, pedb = _make_excitation()
+        comp = MagicMock()
+        comp.name = "U1"
+        comp.pins = {}
+        pedb.components.instances = {"U1": comp}
+        # Should return False (no pins) without raising TypeError/AttributeError
+        result = exc.create_port_on_component("U1", ["NET1"], port_type="coax_port", reference_net=None)
+        assert result is False
+
+    def test_net_list_not_mutated_by_caller(self):
+        """The caller's net_list must not be modified after the call."""
+        exc, pedb = _make_excitation()
+        comp = MagicMock()
+        comp.name = "U1"
+        comp.pins = {}
+        pedb.components.instances = {"U1": comp}
+        original = ["NET1", "GND"]
+        caller_list = list(original)
+        exc.create_port_on_component("U1", caller_list, port_type="coax_port", reference_net="GND")
+        assert caller_list == original, "create_port_on_component must not mutate the caller's net_list"
+
+    def test_coax_port_no_ref_pins_warns_not_errors(self):
+        """For coax_port, missing reference pins should only warn, not hard-fail.
+
+        The method must continue past the ref-pin check and attempt solder-ball creation.
+        """
+        exc, pedb = _make_excitation()
+
+        signal_pin = self._make_signal_pin("NET1")
+        comp = MagicMock()
+        comp.name = "U1"
+        # Component has a signal pin on NET1 but nothing on GND
+        comp.pins = {"Pin1": signal_pin}
+        pedb.components.instances = {"U1": comp}
+
+        # Stub out the downstream calls that follow the ref-pin check
+        pedb.padstacks.get_pad_parameters.return_value = (1, [100e-6, 100e-6])
+        pedb.components.instances["U1"].solder_ball_height = 50e-6
+        pedb.components.instances["U1"].solder_ball_diameter = [100e-6, 100e-6]
+
+        logged_warnings = []
+        mock_logger = MagicMock()
+        mock_logger.warning.side_effect = lambda msg: logged_warnings.append(msg)
+
+        with patch.object(type(exc), "_logger", new_callable=lambda: property(lambda self: mock_logger)):
+            with (
+                patch.object(exc._pedb.components, "set_solder_ball"),
+                patch.object(exc._pedb.excitation_manager, "create_coax_port"),
+            ):
+                exc.create_port_on_component("U1", ["NET1"], port_type="coax_port", reference_net="GND")
+
+        # A warning (not an error) must have been emitted about missing ref pins
+        assert any("reference" in (w or "").lower() for w in logged_warnings), (
+            "Expected a warning about missing reference pins, got: " + str(logged_warnings)
+        )
+        # The error logger must NOT have been called for this path
+        mock_logger.error.assert_not_called()
+
+    def test_coax_port_reference_net_none_empty_list_no_warning(self):
+        """When reference_net is None, no warning about missing ref pins should be emitted."""
+        exc, pedb = _make_excitation()
+        comp = MagicMock()
+        comp.name = "U1"
+        comp.pins = {}
+        pedb.components.instances = {"U1": comp}
+        logged_warnings = []
+        mock_logger = MagicMock()
+        mock_logger.warning.side_effect = lambda msg: logged_warnings.append(msg)
+
+        with patch.object(type(exc), "_logger", new_callable=lambda: property(lambda self: mock_logger)):
+            exc.create_port_on_component("U1", ["NET1"], port_type="coax_port", reference_net=None)
+
+        # warning about ref pins is only issued when reference_net was explicitly provided
+        for w in logged_warnings:
+            assert "reference" not in (w or "").lower(), f"Unexpected ref-pin warning when reference_net=None: {w}"
+
+
 class TestCreatePortOnPinsValidation:
     def test_no_pins_raises_runtime_warning(self):
         exc, pedb = _make_excitation()


### PR DESCRIPTION
This PR is addressing issue #2420 with adding the possibility to not pass reference net when coax port is used since not net is used.

closes #2420 