### PR TITLE
FEAT: trace with arc

### DIFF
--- a/doc/changelog.d/2476.added.md
+++ b/doc/changelog.d/2476.added.md
@@ -1,0 +1,1 @@
+Trace with arc

--- a/src/pyedb/dotnet/database/modeler.py
+++ b/src/pyedb/dotnet/database/modeler.py
@@ -237,7 +237,9 @@ class Modeler:
         else:
             corner_style = self._edb.Cell.Primitive.PathCornerStyle.MiterCorner  # pragma: no cover
 
-        pointlists = [self._pedb.point_data(i[0]) if len(i)==1 else self._pedb.point_data(i[0], i[1]) for i in path_list.points]
+        pointlists = [
+            self._pedb.point_data(i[0]) if len(i) == 1 else self._pedb.point_data(i[0], i[1]) for i in path_list.points
+        ]
         polygonData = self._edb.Geometry.PolygonData(convert_py_list_to_net_list(pointlists), False)
         polygon = self._edb.Cell.Primitive.Path.Create(
             self._active_layout,

--- a/src/pyedb/dotnet/database/modeler.py
+++ b/src/pyedb/dotnet/database/modeler.py
@@ -237,7 +237,7 @@ class Modeler:
         else:
             corner_style = self._edb.Cell.Primitive.PathCornerStyle.MiterCorner  # pragma: no cover
 
-        pointlists = [self._pedb.point_data(i[0], i[1]) for i in path_list.points]
+        pointlists = [self._pedb.point_data(i[0]) if len(i)==1 else self._pedb.point_data(i[0], i[1]) for i in path_list.points]
         polygonData = self._edb.Geometry.PolygonData(convert_py_list_to_net_list(pointlists), False)
         polygon = self._edb.Cell.Primitive.Path.Create(
             self._active_layout,

--- a/tests/system/test_edb_modeler.py
+++ b/tests/system/test_edb_modeler.py
@@ -322,6 +322,19 @@ class TestClass(BaseTestClass):
         # assert trace.get_center_line()[-1] == [0.001, 0.002]
         edbapp.close(terminate_rpc_session=False)
 
+    def test_modeler_create_trace_width_arc(self):
+        """Create a trace based on a list of points."""
+        edbapp = self.edb_examples.get_si_verse()
+        points = [
+            [-0.025, -0.02],
+            [0.01],
+            [0.025, -0.02],
+            [0.025, 0.02],
+        ]
+        trace = edbapp.modeler.create_trace(points, "1_Top")
+        assert trace.center_line[1][0] == 0.01
+        edbapp.close(terminate_rpc_session=False)
+
     def test_modeler_add_void(self):
         """Add a void into a shape."""
         # Done


### PR DESCRIPTION
Enhance create_trace to support arc height
```
        edbapp = Edb()
        points = [
            [-0.025, -0.02],
            [0.01],  # this is the arc height
            [0.025, -0.02],
            [0.025, 0.02],
        ]
        trace = edbapp.modeler.create_trace(points, "1_Top")
```