### PR TITLE
CHORE: Few updates to the `dependabot.yml` configuration file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,10 @@ updates:
   - package-ecosystem: "uv" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "saturday"
+      time: "06:00"
+      timezone: "Europe/Paris"
     cooldown:
       default-days: 7
       include:
@@ -22,11 +25,22 @@ updates:
       prefix: "BUILD(uv)"
 
   - package-ecosystem: "github-actions"
-    cooldown:
-      default-days: 10 # Fallback cooldown if no specific rule applies
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "saturday"
+      time: "06:00"
+      timezone: "Europe/Paris"
+    groups:
+      ansys-actions:
+        patterns:
+          - "ansys/actions/*"
+    cooldown:
+      default-days: 10 # Fallback cooldown if no specific rule applies
+      include:
+        - "*"  # Include all dependencies in cooldown
+      exclude:
+        - "ansys/actions"
     assignees:
       - "svandenb-dev"
       - "hui-zhou-a"
@@ -37,18 +51,18 @@ updates:
       prefix: "BUILD(actions)"
 
   - package-ecosystem: "pre-commit"
-    cooldown:
-      default-days: 7 # Fallback cooldown if no specific rule applies
-      include:
-        - "*"  # Include all dependencies in cooldown
-      exclude:
-        - "ansys/pre-commit-hooks"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "saturday"
       time: "06:00"
       timezone: "Europe/Paris"
+    cooldown:
+      default-days: 7 # Fallback cooldown if no specific rule applies
+      include:
+        - "*"  # Include all dependencies in cooldown
+      exclude:
+        - "ansys/pre-commit-hooks"
     assignees:
       - "svandenb-dev"
       - "hui-zhou-a"

--- a/doc/changelog.d/2525.maintenance.md
+++ b/doc/changelog.d/2525.maintenance.md
@@ -1,0 +1,1 @@
+Few updates to the \`dependabot.yml\` configuration file


### PR DESCRIPTION
This PR is performing a few updates to the `dependabot.yml` configuration file:
* For the `uv` package-ecosystem, the update frequency is reduced from daily to weekly.
* For the `github-actions` package-ecosystem, the update frequency is similarly reduced from daily to weekly. Additionally, a group is defined for the `ansys/actions`, which will have the effect of consolidating the now-weekly updates related to our actions into a single weekly PR. The `ansys/actions` are also excluded from the cooldown.
* Nothing is changed for the `pre-commit` package-ecosystem (only formatting).

In short, with these changes all dependabot updates will occur once a week on Saturday and updates related to the `ansys/actions` will be grouped. This should help reduce the noise and disruption from the dependabot updates in pyedb.