### PR TITLE
FIX: group location fixed

### DIFF
--- a/doc/changelog.d/2543.fixed.md
+++ b/doc/changelog.d/2543.fixed.md
@@ -1,0 +1,1 @@
+Group location fixed

--- a/src/pyedb/grpc/database/hierarchy/group.py
+++ b/src/pyedb/grpc/database/hierarchy/group.py
@@ -99,12 +99,12 @@ class Group:
 
         Returns
         -------
-        List
-            [x, y].
+        tuple[float, float]
+            (x, y) coordinates.
 
         """
         location = self.core.location
-        return self._pedb.value(location[0]), location[1].value
+        return location[0].value, location[1].value
 
     @location.setter
     def location(self, value: tuple | list):

--- a/src/pyedb/grpc/database/hierarchy/group.py
+++ b/src/pyedb/grpc/database/hierarchy/group.py
@@ -104,7 +104,7 @@ class Group:
 
         """
         location = self.core.location
-        return location[0].value, location[1].value
+        return self._pedb.value(location[0]), self._pedb.value(location[1])
 
     @location.setter
     def location(self, value: tuple | list):


### PR DESCRIPTION
This PR is addressing issue #2542 with fixing bad location tuple format. It was returning tuple (x, y) with X as Value and y as float.

closes #2542 